### PR TITLE
docs: add missing legal files

### DIFF
--- a/CLA
+++ b/CLA
@@ -1,0 +1,87 @@
+lowRISC CIC
+Contributor License Agreement ("Agreement") v1.0
+
+You accept and agree to the following terms and conditions for Your present and
+future Contributions submitted to the Project. Except for the license granted
+herein to the Project and recipients of software distributed by the Project,
+You reserve all right, title, and interest in and to Your Contributions.
+
+1. Definitions.
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by
+the copyright owner that is making this Agreement with the Project. For legal
+entities, the entity making a Contribution and all other entities that control,
+are controlled by, or are under common control with that entity are considered
+to be a single Contributor. For the purposes of this definition, "control"
+means (i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial ownership
+of such entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Project for inclusion in, or documentation of, any of the
+products owned or managed by the Project (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to the Project or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of, the
+Project for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+Agreement, You hereby grant to the Project and to recipients of software
+distributed by the Project a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+Agreement, You hereby grant to the Project and to recipients of the Work
+distributed by the Project a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable by You
+that are necessarily infringed by Your Contribution(s) alone or by combination
+of Your Contribution(s)  with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or any other
+entity (including a cross-claim or counterclaim in a lawsuit) alleging that
+your Contribution, or the Work to which you have contributed, constitutes
+direct or contributory patent infringement, then any patent licenses granted to
+that entity under this Agreement for that Contribution or Work shall terminate
+as of the date such litigation is filed.
+
+4. You represent that you are legally entitled to grant the above license. If
+your employer(s) has rights to intellectual property that you create that
+includes your Contributions, you represent that you have received permission to
+make Contributions on behalf of that employer, that your employer has waived
+such rights for your Contributions to the Project, or that your employer has
+executed a separate Corporate CLA with the Project.
+
+5. You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license or
+other restriction (including, but not limited to, related patents and
+trademarks) of which you are personally aware and which are associated with any
+part of Your Contributions.
+
+6. You are not expected to provide support for Your Contributions, except to
+the extent You desire to provide support. You may provide support for free, for
+a fee, or not at all. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation, You may
+submit it to the Project separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify the Project of any facts or circumstances of which you
+become aware that would make these representations inaccurate in any respect.
+
+Please sign: __________________________________ Date: ________________

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+<!--
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+-->
+# Contributing code to the opentitan repository
+
+## Contributor License Agreement
+
+Contributions to OpenTitan must be accompanied by sign-off text that indicates
+acceptance of the Contributor License Agreement (see [CLA](CLA) for full
+text), which is closely derived from the Apache Individual Contributor License
+Agreement. The sign-off text must be included once per commit, in the commit
+message. The sign-off can be automatically inserted using a command such as
+`git commit -s`, which will generate the text in the form:
+`Signed-off-by: Random J Developer <random@developer.example.org>`
+
+By adding this sign-off, you are certifying:
+
+_By signing-off on this submission, I agree to be bound by the terms of the
+Contributor License Agreement located at the root of the project repository,
+and I agree that this submission constitutes a "Contribution" under that
+Agreement._
+
+Please note that this project and any contributions to it are public and that
+a record of all contributions (including any personal information submitted
+with it, including a sign-off) is maintained indefinitely and may be
+redistributed consistent with this project or the open source license(s)
+involved.
+
+## Quick guidelines
+
+* Keep a clean commit history. This means no merge commits, and no long series
+  of "fixup" patches (rebase or squash as appropriate). Structure work as a
+  series of logically ordered, atomic patches. `git rebase -i` is your friend.
+* Changes should be made via pull request, with review. A pull request will be
+  committed by a "committer" (an account listed in `COMMITTERS`) once it has
+  had an explicit positive review.
+* When changes are restricted to a specific area, you are recommended to add a
+  tag to the beginning of the first line of the commit message in square
+  brackets. e.g. "[uart] Fix bug #157".
+* Code review is not design review and doesn't remove the need for discussing
+  implementation options. If you would like to make a large-scale change or
+  discuss multiple implementation options, discuss on the mailing list.
+* Create pull requests from a fork rather than making new branches in
+  `github.com/lowrisc/opentitan`.
+* Do not attempt to commit code with a non-Apache license without discussing
+  first.
+* If a relevant bug or tracking issue exists, reference it in the pull request
+  and commits.
+* Do not report security vulnerabilities through public GitHub issues or pull
+  requests. For instructions on how to report vulnerabilities, please consult
+  SECURITY.md.
+
+Please see [Contributing to OpenTitan](https://opentitan.org/book/doc/contributing)
+for more general guidance.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+The OpenTitan Project
+Copyright 2024 lowRISC contributors (OpenTitan project).
+
+This product includes hardware and/or software developed as part of the
+OpenTitan(R) project (https://www.opentitan.org,
+https://github.com/lowRISC/opentitan).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+<!--
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+-->
+Please refer to https://github.com/lowRISC/opentitan/blob/master/SECURITY.md

--- a/scripts/license_check.py
+++ b/scripts/license_check.py
@@ -17,7 +17,9 @@ LICENSE = (
 )
 
 IGNORE_NAMES = [
+    "CLA",
     "LICENSE",
+    "NOTICE",
     ".python-version",
 ]
 


### PR DESCRIPTION
Adds some missing files from the OpenTitan repo.

- [x] CLA - copied no changes
- [x] CONTRIBUTING.md - copied added licence header to satisfy license checker
- [x] NOTICE - copied no changes
- [x] SECURITY.md - added a reference to the same file in the OpenTitan repo

The CLA and NOTICE files have also been added to the exclude list for the license header checker. They are plain text and so can't take a HTML comment section as the Markdown files can.