### PR TITLE
Fix circular import & add a regression test

### DIFF
--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -9,11 +9,10 @@ import random
 import shlex
 from collections.abc import Mapping
 from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from tabulate import tabulate
 
-from dvsim.flow.sim import SimCfg
 from dvsim.job.time import JobTime
 from dvsim.launcher.factory import get_launcher
 from dvsim.logging import log
@@ -24,6 +23,9 @@ from dvsim.utils import (
     rm_path,
     subst_wildcards,
 )
+
+if TYPE_CHECKING:
+    from dvsim.flow.sim import SimCfg
 
 
 class Deploy:
@@ -50,7 +52,7 @@ class Deploy:
         """Get a string representation of the deployment object."""
         return pprint.pformat(self.__dict__) if log.isEnabledFor(log.VERBOSE) else self.full_name
 
-    def __init__(self, sim_cfg: SimCfg) -> None:
+    def __init__(self, sim_cfg: "SimCfg") -> None:
         """Initialise deployment object.
 
         Args:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DVSim Tests."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test the DVSim cli."""
+
+from hamcrest import assert_that, calling, raises
+
+from dvsim.cli import main
+
+
+def test_cli() -> None:
+    """Test that the CLI can be called without args.
+
+    This doesn't test anything specific, only that the cli module can be
+    imported without errors and main function executes without errors. The
+    expectation is that a usage message is presented.
+    """
+    assert_that(calling(main).with_args(), raises(SystemExit))


### PR DESCRIPTION
In recent type hint improvements a circular import issue was introduced. This is currently not caught in our tests, only running `dvsim` catches this issue.

- [x] Fix the circular import by adding a `TYPE_CHECKING` guard to the type only import. The longer term solution is probably refactor the code to avoid issues like this.
- [x] Add test to import the CLI and run it with no args as a means to checking for basic issues like this.