### PR TITLE
fix: regression

### DIFF
--- a/src/dvsim/flow/base.py
+++ b/src/dvsim/flow/base.py
@@ -132,7 +132,9 @@ class FlowCfg:
                 self._load_child_cfg(entry, mk_config)
 
         if self.rel_path == "":
-            self.rel_path = Path(self.flow_cfg_file).parent.replace(self.proj_root + "/", "")
+            self.rel_path = str(
+                Path(self.flow_cfg_file).parent.relative_to(self.proj_root),
+            )
 
         # Process overrides before substituting wildcards
         self._process_overrides()


### PR DESCRIPTION
Fix regression introduced where string operations were being attempted on Path object. Replace the operation with an equivalent Pathlib operation and then cast back to a string as otherwise the wildcard substitution fails.

This kind of regression highlights the need for integration tests that check a representative config can be loaded correctly. Right now it's quite difficult to refactor without introducing bugs like this with seemingly innocuous changes.