### PR TITLE
feat: summary report more dashboard like

### DIFF
--- a/src/dvsim/flow/sim.py
+++ b/src/dvsim/flow/sim.py
@@ -29,6 +29,7 @@ from dvsim.report.data import FlowResults, IPMeta, Testpoint, TestResult, TestSt
 from dvsim.sim_results import SimResults
 from dvsim.test import Test
 from dvsim.testplan import Testplan
+from dvsim.tool.utils import get_sim_tool_plugin
 from dvsim.utils import TS_FORMAT, rm_path
 
 # This affects the bucketizer failure report.
@@ -684,6 +685,7 @@ class SimCfg(FlowCfg):
 
         # --- Coverage ---
         coverage: dict[str, float | None] = {}
+        coverage_model = None
         if self.cov_report_deploy:
             for k, v in self.cov_report_deploy.cov_results_dict.items():
                 try:
@@ -691,13 +693,17 @@ class SimCfg(FlowCfg):
                 except (ValueError, TypeError, AttributeError):
                     coverage[k.lower()] = None
 
+        coverage_model = get_sim_tool_plugin(self.tool).get_coverage_metrics(
+            raw_metrics=coverage,
+        )
+
         # --- Final result ---
         return FlowResults(
             block=block,
             tool=tool,
             timestamp=timestamp,
             stages=stages,
-            coverage=coverage,
+            coverage=coverage_model,
             passed=total_passed,
             total=total_runs,
             percent=100.0 * total_passed / total_runs if total_runs else 0.0,

--- a/src/dvsim/report/data.py
+++ b/src/dvsim/report/data.py
@@ -95,6 +95,75 @@ class TestStage(BaseModel):
     """Percentage test pass rate."""
 
 
+class CodeCoverageMetrics(BaseModel):
+    """CodeCoverage metrics."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    block: float | None
+    """Block Coverage (%) - did this part of the code execute?"""
+    line_statement: float | None
+    """Line/Statement Coverage (%) - did this part of the code execute?"""
+    branch: float | None
+    """Branch Coverage (%) - did this if/case take all paths?"""
+    condition_expression: float | None
+    """Condition/Expression Coverage (%) - did the logic evaluate to 0 & 1?"""
+    toggle: float | None
+    """Toggle Coverage (%) - did the signal wiggle?"""
+    fsm: float | None
+    """FSM Coverage (%) - did the state machine transition?"""
+
+    @property
+    def average(self) -> float | None:
+        """Average code coverage (%)."""
+        all_cov = [
+            c
+            for c in [
+                self.line_statement,
+                self.branch,
+                self.condition_expression,
+                self.toggle,
+                self.fsm,
+            ]
+            if c is not None
+        ]
+
+        if len(all_cov) == 0:
+            return None
+
+        return sum(all_cov) / len(all_cov)
+
+
+class CoverageMetrics(BaseModel):
+    """Coverage metrics."""
+
+    code: CodeCoverageMetrics | None
+    """Code Coverage."""
+    assertion: float | None
+    """Assertion Coverage."""
+    functional: float | None
+    """Functional coverage."""
+
+    @property
+    def average(self) -> float | None:
+        """Average code coverage (%) or None if there is no coverage."""
+        code = self.code.average if self.code is not None else None
+        all_cov = [
+            c
+            for c in [
+                code,
+                self.assertion,
+                self.functional,
+            ]
+            if c is not None
+        ]
+
+        if len(all_cov) == 0:
+            return None
+
+        return sum(all_cov) / len(all_cov)
+
+
 class FlowResults(BaseModel):
     """Flow results data."""
 
@@ -109,7 +178,7 @@ class FlowResults(BaseModel):
 
     stages: Mapping[str, TestStage]
     """Results per test stage."""
-    coverage: Mapping[str, float | None]
+    coverage: CoverageMetrics | None
     """Coverage metrics."""
 
     passed: int

--- a/src/dvsim/templates/reports/block_report.html
+++ b/src/dvsim/templates/reports/block_report.html
@@ -91,21 +91,39 @@
             </span>
         </div>
 
+{% macro coverage_stat(cov, kind, label) %}
+    {% if cov and cov|attr(kind) is not none %}
+        {% set value = cov|attr(kind) %}
+        <div class="col">
+            <ul class="list-group list-group-horizontal">
+                <li class="list-group-item list-group-item-secondary px-2 py-1">
+                    {{ label }}
+                </li>
+                <li class="list-group-item py-1">{{ "%.2f"|format(value) }} %</li>
+            </ul>
+        </div>
+    {% endif %}
+{% endmacro %}
+
+
         {% if coverage %}
         <div class="col-4 col-md-6">
             <div class="text-center mb-2">Coverage statistics</div>
             <div class="container small">
                 <div class="row g-0 row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4">
-                    {% for name, val in coverage.items() %}
-                    <div class="col">
-                        <ul class="list-group list-group-horizontal">
-                            <li class="list-group-item list-group-item-secondary px-2 py-1">
-                                {{ name }}
-                            </li>
-                            <li class="list-group-item py-1">{{ val }}</li>
-                        </ul>
-                    </div>
-                    {% endfor %}
+                    {{ coverage_stat(coverage, "average", "Total") }}
+
+                    {% set code = coverage.code %}
+                    {{ coverage_stat(code, "average", "code") }}
+                    {{ coverage_stat(coverage, "assertion", "assert") }}
+                    {{ coverage_stat(coverage, "functional", "func") }}
+
+                    {{ coverage_stat(code, "block", "block") }}
+                    {{ coverage_stat(code, "line_statement", "line") }}
+                    {{ coverage_stat(code, "branch", "branch") }}
+                    {{ coverage_stat(code, "condition_expression", "cond") }}
+                    {{ coverage_stat(code, "toggle", "toggle") }}
+                    {{ coverage_stat(code, "fsm", "FSM") }}
                 </div>
             </div>
         </div>

--- a/src/dvsim/templates/reports/summary_report.html
+++ b/src/dvsim/templates/reports/summary_report.html
@@ -88,16 +88,44 @@
         </div>
     </div>
 
+{% macro coverage_cell(cov, kind) %}
+    {% if cov and cov|attr(kind) is not none %}
+        {% set value = cov|attr(kind) %}
+        <td class="c{{ (value / 10)|int }}">{{ "%.2f"|format(value) }}</td>
+    {% else %}
+        <td class="text-muted">-</td>
+    {% endif %}
+{% endmacro %}
+
     <div class="row py-3">
         <div class="col">
-            <table class="table table-sm table-hover">
-                <thead>
+            <table class="table table-sm table-hover text-center">
+                <thead class="table-light align-middle">
                     <tr>
-                        <th>Block</th>
+                        <th rowspan="2">Block</th>
+                        <th colspan="3">Tests</th>
+                        <th colspan="4" class="bg-secondary text-white">Coverage Summary</th>
+                        <th colspan="6">Code Coverage</th>
+                    </tr>
+                    <tr>
+                        <!-- Tests sub-headers -->
                         <th>Pass</th>
                         <th>Total</th>
                         <th>%</th>
-                        <th>Cov</th>
+
+                        <!-- Coverage Summary sub-headers -->
+                        <th class="bg-secondary text-white">Overall</th>
+                        <th class="bg-secondary text-white">Code</th>
+                        <th class="bg-secondary text-white">Functional</th>
+                        <th class="bg-secondary text-white">Assertion</th>
+
+                        <!-- Code Coverage sub-headers -->
+                        <th>Block</th>
+                        <th>Line</th>
+                        <th>Branch</th>
+                        <th>Condition</th>
+                        <th>Toggle</th>
+                        <th>FSM</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -114,19 +142,20 @@
                             <td class="c{{ (flow.percent / 10)|int }}">
                                 {{ "%.2f" | format(flow.percent) }}
                             </td>
-                            <td class="
-                                {% if flow.coverage and flow.coverage.get('score') is not none %}
-                                    c{{ (flow.coverage.score / 10)|int }}
-                                {% else %}
-                                    text-muted
-                                {% endif %}
-                            ">
-                                {% if flow.coverage and flow.coverage.get('score') is not none %}
-                                    {{ "%.2f" | format(flow.coverage.score) }}
-                                {% else %}
-                                    -
-                                {% endif %}
-                            </td>
+                            {% set cov = flow.coverage %}
+                            {{ coverage_cell(cov, "average") }}
+
+                            {% set code = cov|attr("code") %}
+                            {{ coverage_cell(code, "average") }}
+                            {{ coverage_cell(cov, "functional") }}
+                            {{ coverage_cell(cov, "assertion") }}
+
+                            {{ coverage_cell(code, "block") }}
+                            {{ coverage_cell(code, "line_statement") }}
+                            {{ coverage_cell(code, "branch") }}
+                            {{ coverage_cell(code, "condition_expression") }}
+                            {{ coverage_cell(code, "toggle") }}
+                            {{ coverage_cell(code, "fsm") }}
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/src/dvsim/tool/sim.py
+++ b/src/dvsim/tool/sim.py
@@ -4,9 +4,11 @@
 
 """EDA simulation tool interface."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Protocol, runtime_checkable
+
+from dvsim.report.data import CoverageMetrics
 
 __all__ = ("SimTool",)
 
@@ -64,6 +66,19 @@ class SimTool(Protocol):
 
         Raises:
             RuntimeError: exception if the search pattern is not found.
+
+        """
+        ...
+
+    @staticmethod
+    def get_coverage_metrics(raw_metrics: Mapping[str, float | None] | None) -> CoverageMetrics:
+        """Get a CoverageMetrics model from raw coverage data.
+
+        Args:
+            raw_metrics: raw coverage metrics as parsed from the tool.
+
+        Returns:
+            CoverageMetrics model.
 
         """
         ...

--- a/src/dvsim/tool/vcs.py
+++ b/src/dvsim/tool/vcs.py
@@ -5,8 +5,10 @@
 """EDA tool plugin providing VCS support to DVSim."""
 
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+
+from dvsim.report.data import CodeCoverageMetrics, CoverageMetrics
 
 __all__ = ("VCS",)
 
@@ -103,3 +105,30 @@ class VCS:
 
         msg = "Simulated time not found in the log."
         raise RuntimeError(msg)
+
+    @staticmethod
+    def get_coverage_metrics(raw_metrics: Mapping[str, float | None] | None) -> CoverageMetrics:
+        """Get a CoverageMetrics model from raw coverage data.
+
+        Args:
+            raw_metrics: raw coverage metrics as parsed from the tool.
+
+        Returns:
+            CoverageMetrics model.
+
+        """
+        if raw_metrics is None:
+            return CoverageMetrics(code=None, assertion=None, functional=None)
+
+        return CoverageMetrics(
+            functional=raw_metrics.get("group"),
+            assertion=raw_metrics.get("assert"),
+            code=CodeCoverageMetrics(
+                block=None,
+                line_statement=raw_metrics.get("line"),
+                branch=raw_metrics.get("branch"),
+                condition_expression=raw_metrics.get("cond"),
+                toggle=raw_metrics.get("toggle"),
+                fsm=raw_metrics.get("fsm"),
+            ),
+        )

--- a/src/dvsim/tool/xcelium.py
+++ b/src/dvsim/tool/xcelium.py
@@ -6,8 +6,10 @@
 
 import re
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+
+from dvsim.report.data import CodeCoverageMetrics, CoverageMetrics
 
 __all__ = ("Xcelium",)
 
@@ -128,3 +130,30 @@ class Xcelium:
 
         msg = "Simulated time not found in the log."
         raise RuntimeError(msg)
+
+    @staticmethod
+    def get_coverage_metrics(raw_metrics: Mapping[str, float | None] | None) -> CoverageMetrics:
+        """Get a CoverageMetrics model from raw coverage data.
+
+        Args:
+            raw_metrics: raw coverage metrics as parsed from the tool.
+
+        Returns:
+            CoverageMetrics model.
+
+        """
+        if raw_metrics is None:
+            return CoverageMetrics(code=None, assertion=None, functional=None)
+
+        return CoverageMetrics(
+            functional=raw_metrics.get("covergroup"),
+            assertion=raw_metrics.get("assertion"),
+            code=CodeCoverageMetrics(
+                block=raw_metrics.get("block"),
+                line_statement=raw_metrics.get("statement"),
+                branch=raw_metrics.get("branch"),
+                condition_expression=raw_metrics.get("cond"),
+                toggle=raw_metrics.get("toggle"),
+                fsm=raw_metrics.get("fsm"),
+            ),
+        )


### PR DESCRIPTION
Introduce a CoverageMetrics model instead of the dict. Create a new method on the tool plugins to convert from eda tool specific coverage fields to generic names that match the opentitan-site dashboard fields.

Update the report summary and block report templates to use the new model. Add the extra fields in the summary report to make it more like the dashboard (contain the same information).

<img width="840" height="231" alt="image" src="https://github.com/user-attachments/assets/b4ef4417-582b-4ffb-a0b1-dd758f78390d" />


Fixes: #20 