### PR TITLE
fix: Don't use python311 datetime alias

### DIFF
--- a/src/dvsim/cli/run.py
+++ b/src/dvsim/cli/run.py
@@ -850,7 +850,7 @@ def main() -> None:
         args.cfg = os.path.join(proj_root, cfg_path)
 
     # Add timestamp to args that all downstream objects can use.
-    curr_ts = datetime.datetime.now(datetime.UTC)
+    curr_ts = datetime.datetime.now(datetime.timezone.utc)
     args.timestamp_long = curr_ts.strftime(TS_FORMAT_LONG)
     args.timestamp = curr_ts.strftime(TS_FORMAT)
 


### PR DESCRIPTION
Does not work for python310, which we need to support.