### PR TITLE
Add DVSim version to generated reports

### DIFF
--- a/src/dvsim/sim/data.py
+++ b/src/dvsim/sim/data.py
@@ -233,6 +233,9 @@ class SimResultsSummary(BaseModel):
     top: IPMeta
     """Meta data for the top level config."""
 
+    version: str | None
+    """The version of DVSim being used, if applicable."""
+
     timestamp: datetime
     """Run time stamp."""
 

--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -9,6 +9,7 @@ import sys
 from collections import OrderedDict, defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import ClassVar
 
@@ -638,6 +639,12 @@ class SimCfg(FlowCfg):
                 .isoformat()
             )
 
+            try:
+                dvsim_version = version("dvsim").strip()
+            except PackageNotFoundError as e:
+                log.debug("DVSim package not found: %s", str(e))
+                dvsim_version = None
+
             results_summary = SimResultsSummary(
                 top=IPMeta(
                     name=self.name,
@@ -646,6 +653,7 @@ class SimCfg(FlowCfg):
                     branch=self.branch,
                     url=url,
                 ),
+                version=dvsim_version,
                 timestamp=timestamp,
                 flow_results=all_flow_results,
                 report_path=reports_dir,

--- a/src/dvsim/sim/report.py
+++ b/src/dvsim/sim/report.py
@@ -17,12 +17,13 @@ __all__ = (
 )
 
 
-def gen_block_report(results: SimFlowResults, path: Path) -> None:
+def gen_block_report(results: SimFlowResults, path: Path, version: str | None = None) -> None:
     """Generate a block report.
 
     Args:
         results: flow results for the block
         path: output directory path
+        version: dvsim version used to get results for this block
 
     """
     file_name = (
@@ -42,7 +43,7 @@ def gen_block_report(results: SimFlowResults, path: Path) -> None:
     (path / f"{file_name}.html").write_text(
         render_template(
             path="reports/block_report.html",
-            data={"results": results},
+            data={"results": results, "version": version},
         ),
     )
 
@@ -99,4 +100,4 @@ def gen_reports(summary: SimResultsSummary, path: Path) -> None:
     gen_summary_report(summary=summary, path=path)
 
     for flow_result in summary.flow_results.values():
-        gen_block_report(results=flow_result, path=path)
+        gen_block_report(results=flow_result, path=path, version=summary.version)

--- a/src/dvsim/templates/reports/block_report.html
+++ b/src/dvsim/templates/reports/block_report.html
@@ -40,6 +40,12 @@
             <span class="badge text-bg-secondary">
                 {{ timestamp.strftime("%d/%m/%Y %H:%M:%S") }}
             </span>
+            {% if version %}
+            <a class="badge text-bg-secondary link-underline link-underline-opacity-0"
+                href="https://github.com/lowRISC/dvsim/releases/tag/v{{ version }}">
+                DVSim: v{{ version }}
+            </a>
+            {% endif %}
             <a class="badge text-bg-secondary link-underline link-underline-opacity-0"
                href="{{ block.url }}">
                 sha: {{ block.commit[:7] }}

--- a/src/dvsim/templates/reports/summary_report.html
+++ b/src/dvsim/templates/reports/summary_report.html
@@ -6,6 +6,7 @@
 -->
 {% set top = summary.top %}
 {% set timestamp = summary.timestamp %}
+{% set version = summary.version %}
 <div class="container-md"> 
     <div class="row">
         <div class="col">
@@ -36,6 +37,12 @@
             <span class="badge text-bg-secondary">
                 {{ timestamp.strftime("%d/%m/%Y %H:%M:%S") }}
             </span>
+            {% if version %}
+            <a class="badge text-bg-secondary link-underline link-underline-opacity-0"
+                href="https://github.com/lowRISC/dvsim/releases/tag/v{{ version }}">
+                DVSim: v{{ version }}
+            </a>
+            {% endif %}
             <a class="badge text-bg-secondary link-underline link-underline-opacity-0"
                 href="{{ top.url }}">
                 sha: {{ top.commit[:7] }}


### PR DESCRIPTION
One thing I noticed when looking at the output reports is that DVSim doesn't mention what version of DVSim the report was generated with, despite already providing the commit of the top being tested (for sim flows at least). Since DVSim is undergoing active changes, it seems prescient to record this in the generated reports for the sake of reproducibility.

This PR adds the version that was used to run DVSim to the generated block and summary reports, with a link to the tag of the relevant Github release for that version.