### PR TITLE
Add additional sim flow debug logs

### DIFF
--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -548,6 +548,13 @@ class RunTest(Deploy):
         # Systemverilog accepts seeds with a maximum size of 32 bits.
         self.svseed = int(self.seed) & 0xFFFFFFFF
         self.simulated_time = JobTime()
+        log.debug(
+            "Initializing RunTest for %s test %s no. %d with seed %s",
+            sim_cfg.name,
+            getattr(test, "name", "[unknown]"),
+            index,
+            self.seed,
+        )
         super().__init__(sim_cfg)
 
         # Needs to be after the wildcard expansion to log anything meaningful

--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -467,7 +467,13 @@ class SimCfg(FlowCfg):
 
         self.builds = []
         build_map = {}
-        for build_mode_obj in self.build_list:
+        for i, build_mode_obj in enumerate(self.build_list, start=1):
+            log.debug(
+                "Creating build mode obj %d/%d: %s",
+                i,
+                len(self.build_list),
+                build_mode_obj.name,
+            )
             new_build = CompileSim(build_mode_obj, self)
 
             # It is possible for tests to supply different build modes, but


### PR DESCRIPTION
If I run a large amount of sim jobs (e.g. OpenTitan Earlgrey nightly regression), then even with verbose logs it spends a few minutes with no output on my machine. This PR adds some more debug logs so that we know what DVSim is doing during this time. I am note sure if `DEBUG` is appropriate or if `VERBOSE` is more appropriate here - it is not clear where the line should lie, so please do give any opinions.

*Aside*: it turns out the large runtime is because DVSim generates a new deploy object for each seed and individually runs wildcard processing for each seed, which was giving me ~15 million wildcard expansions for the nightly! I am not sure if this is a required feature because we need seeds to be usable in the wildcards, but even if so, it could be much more efficient to do all non-seed expansion first and then share the result for each seed/deploy. But this probably requires a larger refactor of how DVSim handles cfgs in general...