### PR TITLE
Add main entry points for main and admin CLIs

### DIFF
--- a/src/dvsim/cli/admin.py
+++ b/src/dvsim/cli/admin.py
@@ -4,6 +4,7 @@
 
 """DVSim CLI main entry point."""
 
+import sys
 from importlib.metadata import version
 from pathlib import Path
 
@@ -43,3 +44,7 @@ def gen(json_path: Path, output_dir: Path) -> None:
     results: SimResultsSummary = SimResultsSummary.load(path=json_path)
 
     gen_reports(summary=results, path=output_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/src/dvsim/cli/run.py
+++ b/src/dvsim/cli/run.py
@@ -279,7 +279,7 @@ def parse_reseed_multiplier(as_str: str) -> float:
     return ret
 
 
-def parse_args():
+def parse_args(argv: list[str] | None = None):
     cfg_metavar = "<cfg-hjson-file>"
     parser = argparse.ArgumentParser(
         description=wrapped_docstring(),
@@ -790,7 +790,7 @@ def parse_args():
         help=("Use a fake launcher that generates random results"),
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv) if argv else parser.parse_args()
 
     # Check conflicts
     # interactive and remote, r
@@ -816,9 +816,9 @@ def parse_args():
     return args
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """DVSim CLI entry point."""
-    args = parse_args()
+    args = parse_args(argv)
 
     configure_logging(
         verbose=args.verbose is not None,
@@ -912,3 +912,7 @@ def main() -> None:
     if cfg.has_errors():
         log.error("Errors were encountered in this run.")
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Not sure if there is any reason these were missing, but if there isn't then this PR introduces explicit main entry points to the two CLIs, allowing them to be run with Python directly. It can be helpful if making changes to DVSim and you want/need to run DVSim without rebuilding DVSim or using an editable package