### PR TITLE
Convert status printer to singleton and keep context

### DIFF
--- a/src/dvsim/cli/run.py
+++ b/src/dvsim/cli/run.py
@@ -44,6 +44,7 @@ from dvsim.launcher.sge import SgeLauncher
 from dvsim.launcher.slurm import SlurmLauncher
 from dvsim.logging import configure_logging, log
 from dvsim.utils import TS_FORMAT, TS_FORMAT_LONG, Timer, rm_path, run_cmd_with_timeout
+from dvsim.utils.status_printer import get_status_printer
 
 # The different categories that can be passed to the --list argument.
 _LIST_CATEGORIES = ["build_modes", "run_modes", "tests", "regressions"]
@@ -916,6 +917,12 @@ def main(argv: list[str] | None = None) -> None:
 
         # Generate results.
         cfg.gen_results(results)
+
+        # Now that we have printed the results from the scheduler, we close the
+        # status printer, to ensure the status remains relevant in the UI context
+        # (for applicable status printers).
+        status_printer = get_status_printer(args.interactive)
+        status_printer.exit()
 
     else:
         log.error("Nothing to run!")

--- a/src/dvsim/scheduler.py
+++ b/src/dvsim/scheduler.py
@@ -249,8 +249,9 @@ class Scheduler:
         finally:
             signal(SIGINT, old_handler)
 
-        # Cleanup the status printer.
-        self._status_printer.exit()
+        # Stop the status printer, but don't exit/close it yet, for reporting purposes.
+        # That will be done by the CLI upon exiting
+        self._status_printer.stop()
 
         # Finish instrumentation and generate the instrumentation report
         self._instrumentation.on_scheduler_end()

--- a/src/dvsim/utils/status_printer.py
+++ b/src/dvsim/utils/status_printer.py
@@ -6,6 +6,7 @@
 
 import sys
 from collections.abc import Sequence
+from typing import ClassVar
 
 import enlighten
 
@@ -54,6 +55,9 @@ class StatusPrinter:
             running:  What jobs are currently still running.
 
         """
+
+    def stop(self) -> None:
+        """Stop the status header/target printing (but keep the printer context)."""
 
     def exit(self) -> None:
         """Do cleanup activities before exiting."""
@@ -136,9 +140,6 @@ class TtyStatusPrinter(StatusPrinter):
         if perc == 100:
             self.target_done[target] = True
 
-    def exit(self) -> None:
-        """Do cleanup activities before exiting."""
-
 
 class EnlightenStatusPrinter(TtyStatusPrinter):
     """Abstraction for printing status using Enlighten.
@@ -163,6 +164,7 @@ class EnlightenStatusPrinter(TtyStatusPrinter):
         self.manager = enlighten.get_manager()
         self.status_header = None
         self.status_target = {}
+        self._stopped = False
 
     def print_header(self) -> None:
         self.status_header = self.manager.status_bar(
@@ -196,28 +198,56 @@ class EnlightenStatusPrinter(TtyStatusPrinter):
         if perc == 100:
             self.target_done[target] = True
 
-    def exit(self) -> None:
-        """Do cleanup activities before exiting."""
+    def stop(self) -> None:
+        """Stop the status header/target printing (but keep the printer context)."""
         if self.status_header is not None:
             self.status_header.close()
         for target in self.status_target:
             self.status_target[target].close()
+        self._stopped = True
+
+    def exit(self) -> None:
+        """Do cleanup activities before exiting (closing the manager context)."""
+        if not self._stopped:
+            self.stop()
         self.manager.stop()
 
 
+class StatusPrinterSingleton:
+    """Singleton for the status printer to uniquely refer to 1 instance at a time."""
+
+    _instance: ClassVar[StatusPrinter | None] = None
+
+    @classmethod
+    def set(cls, instance: StatusPrinter | None) -> None:
+        """Set the stored status printer."""
+        cls._instance = instance
+
+    @classmethod
+    def get(cls) -> StatusPrinter | None:
+        """Get the stored status printer (if it exists)."""
+        return cls._instance
+
+
 def get_status_printer(interactive: bool) -> StatusPrinter:
-    """Get the status printer.
+    """Get the global status printer.
 
     If stdout is a TTY, then return an instance of EnlightenStatusPrinter, else
-    return an instance of StatusPrinter.
+    return an instance of StatusPrinter. If the status printer has already been
+    created, then returns that instance, regardless of given arguments.
     """
+    status_printer = StatusPrinterSingleton.get()
+    if status_printer is not None:
+        return status_printer
+
     if interactive:
-        return StatusPrinter()
-
-    if sys.stdout.isatty():
-        return EnlightenStatusPrinter()
-
-    return TtyStatusPrinter()
+        status_printer = StatusPrinter()
+    elif sys.stdout.isatty():
+        status_printer = EnlightenStatusPrinter()
+    else:
+        status_printer = TtyStatusPrinter()
+    StatusPrinterSingleton.set(status_printer)
+    return status_printer
 
 
 def print_msg_list(msg_list_title, msg_list, max_msg_count=-1):


### PR DESCRIPTION
Convert the status printer to a global singleton instance so that it is no longer tied to the scheduler in specific. After the fix applied in https://github.com/lowRISC/dvsim/pull/91, the `EnglightenStatusPrinter` manager is now correctly stopped - but when we introduce CLI Markdown report logging, it will probably be preferable to have the status remain as one of the last things shown, rather than before all the report logs.

To keep the fix while retaining the original behaviour, this PR breaks apart the status printer `exit()` into two parts - `stop()` and `exit()`. `stop()` indicates we will not be updating it any more, and is called by the scheduler. `exit()` indicates the status printer itself should close its context and exit - this is now called before the end of the CLI execution.