### PR TITLE
Fix error result log reporting for sim flows

### DIFF
--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -795,6 +795,8 @@ class SimCfg(FlowCfg):
         )
 
         failures = BucketedFailures.from_job_status(results=run_results)
+        if failures.buckets:
+            self.errors_seen = True
 
         # --- Final result ---
         return SimFlowResults(


### PR DESCRIPTION
With errors in sim flows, we were not getting an error log or the correct error exit code because the `errors_seen` state variable of the `SimCfg` was not being updated correctly upon job failures.