### PR TITLE
Fix broken ruff lint in CI

### DIFF
--- a/src/dvsim/cli/run.py
+++ b/src/dvsim/cli/run.py
@@ -42,7 +42,7 @@ from dvsim.launcher.lsf import LsfLauncher
 from dvsim.launcher.nc import NcLauncher
 from dvsim.launcher.sge import SgeLauncher
 from dvsim.launcher.slurm import SlurmLauncher
-from dvsim.logging import configure_logging, log, LOG_LEVELS
+from dvsim.logging import LOG_LEVELS, configure_logging, log
 from dvsim.utils import TS_FORMAT, TS_FORMAT_LONG, Timer, rm_path, run_cmd_with_timeout
 from dvsim.utils.status_printer import get_status_printer
 

--- a/src/dvsim/launcher/sge/qsubopts.py
+++ b/src/dvsim/launcher/sge/qsubopts.py
@@ -1106,7 +1106,7 @@ class QSubOptions:
               jsv(1))""",
             )
 
-        if prog in ["qrsh"]:
+        if prog == "qrsh":
             self.parser.add_argument(
                 "-noshell",
                 action="store_true",
@@ -1133,7 +1133,7 @@ class QSubOptions:
               qrsh -noshell /bin/tcsh -f -c 'echo $HOSTNAME'""",
             )
 
-        if prog in ["qrsh"]:
+        if prog == "qrsh":
             self.parser.add_argument(
                 "-nostdin",
                 action="store_true",
@@ -1174,7 +1174,7 @@ class QSubOptions:
               jsv(1))""",
             )
 
-        if prog in ["qalter"]:
+        if prog == "qalter":
             self.parser.add_argument(
                 "-ot",
                 metavar="override_tickets",
@@ -1405,7 +1405,7 @@ class QSubOptions:
               JSV in jsv(1))""",
             )
 
-        if prog in ["qsub"]:
+        if prog == "qsub":
             self.parser.add_argument(
                 "-shell",
                 choices=yesno,
@@ -1477,7 +1477,7 @@ class QSubOptions:
               jsv(1))""",
             )
 
-        if prog in ["qsub"]:
+        if prog == "qsub":
             self.parser.add_argument(
                 "-sync",
                 choices=yesno,
@@ -1632,7 +1632,7 @@ class QSubOptions:
               when 8 slots are free.""",
             )
 
-        if prog in ["qsub"]:
+        if prog == "qsub":
             self.parser.add_argument(
                 "-terse",
                 action="store_true",
@@ -1649,7 +1649,7 @@ class QSubOptions:
               option above or find more information concerning JSV in jsv(1))""",
             )
 
-        if prog in ["qalter"]:
+        if prog == "qalter":
             self.parser.add_argument(
                 "-u",
                 metavar="username",
@@ -1834,7 +1834,7 @@ class QSubOptions:
               find more information concerning JSV in jsv(1))""",
             )
 
-        if prog in ["qsh"]:
+        if prog == "qsh":
             self.parser.add_argument(
                 "xterm_args",
                 nargs="*",

--- a/src/dvsim/logging.py
+++ b/src/dvsim/logging.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import cast
 
 __all__ = (
-    "configure_logging",
     "LOG_LEVELS",
+    "configure_logging",
 )
 
 

--- a/src/dvsim/msg_bucket.py
+++ b/src/dvsim/msg_bucket.py
@@ -25,7 +25,7 @@ class MsgBucket:
             raise RuntimeError(msg)
         self.category = category
         self.severity = severity
-        self.label = label if label else f"{category} {severity}s".title()
+        self.label = label or f"{category} {severity}s".title()
         self.signatures = []
 
     def clear(self) -> None:

--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -530,7 +530,7 @@ class SimCfg(FlowCfg):
             )
 
         # GUI mode is only available for Xcelium for the moment.
-        if (self.gui_debug) and (self.tool not in ["xcelium"]):
+        if (self.gui_debug) and (self.tool != "xcelium"):
             log.error(
                 "GUI debug mode is only available for Xcelium, please remove "
                 "--gui_debug / -gd option or switch to Xcelium tool.",

--- a/src/dvsim/utils/git.py
+++ b/src/dvsim/utils/git.py
@@ -29,7 +29,7 @@ def repo_root(path: Path) -> Path | None:
 
 def git_commit_hash(path: Path | None = None) -> str:
     """Hash of the current git commit."""
-    root = repo_root(path=path if path else Path.cwd())
+    root = repo_root(path=path or Path.cwd())
 
     if root is None:
         log.error("no git repo found at %s", root)


### PR DESCRIPTION
Fix by running `uv sync --all-extras && ruff check --config=ruff-ci.toml --fix` (and manually fixing any remaining failures).