### PR TITLE
Fix git url

### DIFF
--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -42,7 +42,7 @@ from dvsim.test import Test
 from dvsim.testplan import Testplan
 from dvsim.tool.utils import get_sim_tool_plugin
 from dvsim.utils import TS_FORMAT, rm_path
-from dvsim.utils.git import git_commit_hash
+from dvsim.utils.git import git_commit_hash, git_https_url_with_commit
 
 __all__ = ("SimCfg",)
 
@@ -601,12 +601,14 @@ class SimCfg(FlowCfg):
             results: completed job status objects.
 
         """
+        repo_root = Path(self.proj_root)
         reports_dir = Path(self.scratch_base_path) / "reports"
-        commit = git_commit_hash(path=Path(self.proj_root))
-        url = f"https://github.com/lowrisc/opentitan/tree/{commit}"
+        commit = git_commit_hash(path=repo_root)
+        url = git_https_url_with_commit(path=repo_root)
 
         try:
             dvsim_version = version("dvsim").strip()
+
         except PackageNotFoundError as e:
             log.debug("DVSim package not found: %s", str(e))
             dvsim_version = None

--- a/src/dvsim/utils/git.py
+++ b/src/dvsim/utils/git.py
@@ -4,10 +4,11 @@
 
 """Git utility functions."""
 
-import logging as log
 from pathlib import Path
 
 from git import Repo
+
+from dvsim.logging import log
 
 __all__ = ("repo_root",)
 
@@ -32,9 +33,44 @@ def git_commit_hash(path: Path | None = None) -> str:
     root = repo_root(path=path or Path.cwd())
 
     if root is None:
-        log.error("no git repo found at %s", root)
+        log.error("no git repo found at %s", path)
         raise ValueError
 
     r = Repo(root)
 
     return r.head.commit.hexsha
+
+
+def git_origin_url(path: Path | None = None) -> str:
+    """Get the git remote origin url."""
+    root = repo_root(path=path or Path.cwd())
+
+    if root is None:
+        log.error("no git repo found at %s", path)
+        raise ValueError
+
+    r = Repo(root)
+
+    return r.remote().url
+
+
+def git_https_url_with_commit(path: Path | None = None) -> str:
+    """Get an https url that references the current commit.
+
+    Args:
+        path: the path to the git repo
+
+    Returns:
+        str containing the https url
+
+    """
+    url = git_origin_url(path=path)
+    commit = git_commit_hash(path=path)
+
+    url = url.removesuffix(".git")
+
+    prefix = "git@github.com:"
+    if url.startswith(prefix):
+        url = "https://github.com/" + url.removeprefix(prefix)
+
+    return f"{url}/tree/{commit}"

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -4,15 +4,13 @@
 
 """Test git helpers."""
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
+import pytest
 from git import Repo
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, calling, equal_to, raises
 
-from dvsim.utils.git import git_commit_hash, repo_root
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from dvsim.utils.git import git_commit_hash, git_https_url_with_commit, git_origin_url, repo_root
 
 __all__ = ()
 
@@ -21,7 +19,7 @@ class TestGit:
     """Test git helpers."""
 
     @staticmethod
-    def test_repo_root(tmp_path: "Path") -> None:
+    def test_repo_root(tmp_path: Path) -> None:
         """Test git repo root can be found."""
         repo_root_path = tmp_path / "repo"
         repo_root_path.mkdir()
@@ -40,8 +38,14 @@ class TestGit:
         assert_that(repo_root(path=tmp_path), equal_to(None))
 
     @staticmethod
-    def test_git_commit_hash(tmp_path: "Path") -> None:
+    def test_git_commit_hash(tmp_path: Path) -> None:
         """Test that the expected git commit sha is returned."""
+        # Value error if called outside a git repo
+        assert_that(
+            calling(git_commit_hash).with_args(tmp_path),
+            raises(ValueError),
+        )
+
         r = Repo.init(path=tmp_path)
 
         file = tmp_path / "a"
@@ -52,4 +56,62 @@ class TestGit:
         assert_that(
             git_commit_hash(tmp_path),
             equal_to(r.head.commit.hexsha),
+        )
+
+    @staticmethod
+    def test_git_origin_url(tmp_path: Path) -> None:
+        """Test that the expected git remote origin url is returned."""
+        # Value error if called outside a git repo
+        assert_that(
+            calling(git_origin_url).with_args(tmp_path),
+            raises(ValueError),
+        )
+
+        r = Repo.init(path=tmp_path)
+
+        file = tmp_path / "a"
+        file.write_text("file to commit")
+        r.index.add([file])
+        r.index.commit("initial commit")
+
+        # Value error if called outside a git repo
+        assert_that(
+            calling(git_origin_url).with_args(tmp_path),
+            raises(ValueError),
+        )
+
+        url = "git@github.com:lowRISC/test.git"
+        r.create_remote("origin", url)
+
+        assert_that(
+            git_origin_url(tmp_path),
+            equal_to(url),
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("git@github.com:lowRISC/test.git", "https://github.com/lowRISC/test/tree/{commit}"),
+            (
+                "https://github.com/lowRISC/test.git",
+                "https://github.com/lowRISC/test/tree/{commit}",
+            ),
+        ],
+    )
+    def test_git_https_url_with_commit(tmp_path: Path, url: str, expected: str) -> None:
+        """Test that the expected url with commit is returned."""
+        r = Repo.init(path=tmp_path)
+
+        file = tmp_path / "a"
+        file.write_text("file to commit")
+        r.index.add([file])
+        r.index.commit("initial commit")
+
+        r.create_remote("origin", url)
+
+        commit = r.head.commit.hexsha
+        assert_that(
+            git_https_url_with_commit(tmp_path),
+            equal_to(expected.format(commit=commit)),
         )


### PR DESCRIPTION
Derive the HTML report git repo URL from `git remote get_url origin`.