### PR TITLE
fix: set UV_PYTHON in .envrc for NixOS direnv users

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -11,3 +11,7 @@ use flake
 
 # Activate the project venv
 . .venv/bin/activate
+
+# Tell UV to use the venv python, without this it will use system python on
+# NixOS. Which means `uv pip list` will not work.
+export UV_PYTHON=.venv/bin/python


### PR DESCRIPTION
On NixOS, uv resolves the Python interpreter via PATH even when VIRTUAL_ENV is set, falling back to the immutable Nix store Python which rejects writes. Setting UV_PYTHON explicitly in .envrc forces uv to use the venv interpreter for all commands.