### PR TITLE
fix: document `--interactive` reseed assumption

### DIFF
--- a/src/dvsim/cli/run.py
+++ b/src/dvsim/cli/run.py
@@ -536,7 +536,7 @@ def parse_args(argv: list[str] | None = None):
         help=(
             "Run the job in non-GUI interactive mode "
             "accepting manual user inputs and displaying the "
-            "tool outputs transparently."
+            "tool outputs transparently. This implies --reseed 1."
         ),
     )
 


### PR DESCRIPTION
This PR is the first of a series of PRs to rewrite DVSim's core scheduling functionality (Scheduler, status display, launchers / runtime backends) to use an async design, with key goals of long term maintainability and extensibility.

This PR just contains a simple unrelated fix found during the rewrite process. The implied `--reseed 1` is already documented for the `--fixed-seed` argument, but it is also implied if running in interactive mode. Make sure that this is documented in the argparse CLI so that it is more clear to users what is happening when they use this option.