### PR TITLE
fix: stop adding build job dependencies if running with --run-only

### DIFF
--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -565,7 +565,7 @@ class RunTest(Deploy):
                 self.run_timeout_mins,
             )
 
-        if build_job is not None:
+        if build_job is not None and not self.sim_cfg.run_only:
             self.dependencies.append(build_job)
 
         # We did something wrong if build_mode is not the same as the build_job


### PR DESCRIPTION
This PR is the second of a series of PRs to rewrite DVSim's core scheduling functionality (Scheduler, status display, launchers / runtime backends) to use an async design, with key goals of long term maintainability and extensibility.

This PR just contains a simple unrelated fix found during the rewrite process. Whilst using `--run-only` will mean the build jobs themselves will be excluded from the scheduler, we also want the run jobs to not have the build jobs listed as dependencies. This makes our input list of `JobSpec` objects a more well-formed DAG without links to nodes that do not exist, which the scheduler subsequently must ignore.