### PR TITLE
fix: round RSS byte averages in resource instrumentation

### DIFF
--- a/src/dvsim/instrumentation/resources.py
+++ b/src/dvsim/instrumentation/resources.py
@@ -177,7 +177,7 @@ class ResourceInstrumentation(SchedulerInstrumentation):
             self._thread.join()
 
     def _sampling_loop(self) -> None:
-        next_run_at = time.time()
+        next_run_at = time.perf_counter()
         while self._running:
             next_run_at += self.sample_interval
 
@@ -209,7 +209,7 @@ class ResourceInstrumentation(SchedulerInstrumentation):
                 for aggregate in self._running_jobs.values():
                     aggregate.add_sample(sys_rss, sys_cpu)
 
-            sleep_time = max(next_run_at - time.time(), 0)
+            sleep_time = max(next_run_at - time.perf_counter(), 0)
             time.sleep(sleep_time)
 
     def on_scheduler_start(self) -> None:

--- a/src/dvsim/instrumentation/timing.py
+++ b/src/dvsim/instrumentation/timing.py
@@ -85,11 +85,11 @@ class TimingInstrumentation(SchedulerInstrumentation):
 
     def on_scheduler_start(self) -> None:
         """Notify instrumentation that the scheduler has begun."""
-        self._scheduler.start_time = time.time()
+        self._scheduler.start_time = time.perf_counter()
 
     def on_scheduler_end(self) -> None:
         """Notify instrumentation that the scheduler has finished."""
-        self._scheduler.end_time = time.time()
+        self._scheduler.end_time = time.perf_counter()
 
     def on_job_status_change(self, job: JobSpec, status: JobStatus) -> None:
         """Notify instrumentation of a change in status for some scheduled job."""
@@ -100,9 +100,9 @@ class TimingInstrumentation(SchedulerInstrumentation):
             self._jobs[job_id] = job_info
 
         if job_info.start_time is None and status != JobStatus.QUEUED:
-            job_info.start_time = time.time()
+            job_info.start_time = time.perf_counter()
         if status.ended:
-            job_info.end_time = time.time()
+            job_info.end_time = time.perf_counter()
 
     def build_report_fragments(self) -> InstrumentationFragments | None:
         """Build report fragments from the collected instrumentation information."""


### PR DESCRIPTION
This PR is the third of a series of PRs to rewrite DVSim's core scheduling functionality (Scheduler, status display, launchers / runtime backends) to use an async design, with key goals of long term maintainability and extensibility.

This PR just contains a simple unrelated fix found during the rewrite process. Two instrumentation fields for average RSS byte calculations were typed as integers (and are probably most useful as integers), but were given as floats due to the division - so we should round them to match the expected output type. It also moves to use the more appropriate `time.perf_counter` for instrumentation measurements.

See the commit messages for more information. 