### PR TITLE
fix: restore RunTest simulation time parsing

### DIFF
--- a/src/dvsim/launcher/base.py
+++ b/src/dvsim/launcher/base.py
@@ -365,6 +365,13 @@ class Launcher(ABC):
 
         self.job_runtime.set(time, unit)
 
+        if self.job_spec.job_type == "RunTest":
+            try:
+                time, unit = plugin.get_simulated_time(log_text=lines)
+                self.simulated_time.set(time, unit)
+            except RuntimeError as e:
+                log.debug("%s: %s", self.job_spec.full_name, str(e))
+
         if chk_failed or chk_passed:
             for cnt, line in enumerate(lines):
                 if chk_failed and _find_patterns(self.job_spec.fail_patterns, line):


### PR DESCRIPTION
This PR is the sixth of a series of PRs to rewrite DVSim's core scheduling functionality (Scheduler, status display, launchers / runtime backends) to use an async design, with key goals of long term maintainability and extensibility.

This PR contains a fix to the `LocalLauncher` which will be later be incorporated into the newly introduced equivalent async backend. It fixes functionality was accidentally removed in 596d92fa4b0e69bf69b3b23e086db0ba72e3d0aa, meaning that tests no longer reported any simulated time values that were parsed from their logs. This PR reintroduces this functionality via the existing plugins to mimic the original DVSim functionality.