### PR TITLE
fix: count only unique test results during simulation flow result count aggregations

### DIFF
--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -744,6 +744,8 @@ class SimCfg(FlowCfg):
 
         # --- Build stages only from testpoints that have at least one executed test ---
         stage_to_tps: defaultdict[str, dict[str, Testpoint]] = defaultdict(dict)
+        stage_to_trs: defaultdict[str, dict[str, TestResult]] = defaultdict(dict)
+        all_trs: defaultdict[str, TestResult] = {}
 
         def make_test_result(tr) -> TestResult | None:
             if tr.total == 0 and not self.map_full_testplan:
@@ -782,6 +784,10 @@ class SimCfg(FlowCfg):
                 percent=100.0 * tp_passed / tp_total if tp_total else 0.0,
             )
 
+            for name, tr in test_results.items():
+                stage_to_trs[tp.stage][name] = tr
+                all_trs[name] = tr
+
         # 2. Unmapped tests — only if they actually ran
         unmapped_tests: dict[str, TestResult] = {}
         for tr in sim_results.table:
@@ -798,15 +804,16 @@ class SimCfg(FlowCfg):
                 percent=100.0 * tp_passed / tp_total if tp_total else 0.0,
             )
 
+            for name, tr in unmapped_tests.items():
+                stage_to_trs["unmapped"][name] = tr
+                all_trs[name] = tr
+
         # --- Final stage aggregation ---
         stages: dict[str, TestStage] = {}
-        total_passed = total_runs = 0
 
         for stage_name, testpoints in stage_to_tps.items():
-            stage_passed = stage_total = 0
-            for tp in testpoints.values():
-                stage_passed += tp.passed
-                stage_total += tp.total
+            stage_passed = sum(tr.passed for tr in stage_to_trs[stage_name].values())
+            stage_total = sum(tr.total for tr in stage_to_trs[stage_name].values())
 
             stages[stage_name] = TestStage(
                 testpoints=testpoints,
@@ -815,8 +822,8 @@ class SimCfg(FlowCfg):
                 percent=100.0 * stage_passed / stage_total if stage_total else 0.0,
             )
 
-            total_passed += stage_passed
-            total_runs += stage_total
+        total_passed = sum(tr.passed for tr in all_trs.values())
+        total_runs = sum(tr.total for tr in all_trs.values())
 
         # --- Coverage ---
         coverage: dict[str, float | None] = {}


### PR DESCRIPTION
This PR is the seventh of a series of PRs to rewrite DVSim's core scheduling functionality (Scheduler, status display, launchers / runtime backends) to use an async design, with key goals of long term maintainability and extensibility.

This PR contains an independent/unrelated fix for the generated output results that were hindering comparisons with the original DVSim checked into OpenTitan. A single test result can appear in many different testpoints across a stage, and likewise in many different stages across the entire testplan. But, it should really only be counted once per stage and once globally when aggregating - that is, the counts should always reflect the actual number of unique underlying tests run by the scheduler.

*Aside*: this isn't the most clean addition, as this whole test result computation logic could use some refactoring and cleanup (especially with the legacy `Testplan` object that it somewhat duplicates), but for now the priority is on fixing this and getting it working.