### PR TITLE
Fixes for scheduler test issues

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -867,15 +867,14 @@ class TestSchedulingPriority:
             vary_targets=True,
         )
         jobs = [start_job, *weighted_jobs]
-        by_weight_dec = [
-            j.name for j in sorted(weighted_jobs, key=lambda job: job.weight, reverse=True)
-        ]
+        by_weight_dec = sorted(weighted_jobs, key=lambda job: job.weight, reverse=True)
         # Set max parallel = 1 so that order dispatched becomes the priority order
         # With max parallel > 1, jobs of many priorities are dispatched "at once".
         fxt.mock_launcher.max_parallel = 1
         result = Scheduler(jobs, fxt.mock_launcher).run()
-        _assert_result_status(result, 6)
-        assert_that(fxt.mock_ctx.order_started, equal_to([start_job, *by_weight_dec]))
+        _assert_result_status(result, len(jobs))
+        expected_order = [start_job, *by_weight_dec]
+        assert_that(fxt.mock_ctx.order_started, equal_to(expected_order))
 
     @staticmethod
     @pytest.mark.xfail(reason="DVSim does not handle zero weights.")


### PR DESCRIPTION
This PR is the eighth of a series of PRs to rewrite DVSim's core scheduling functionality (Scheduler, status display, launchers / runtime backends) to use an async design, with key goals of long term maintainability and extensibility.

This PR contains a small set of fixes for the scheduler tests that will be required for the tests to pass when moving to use the new async scheduler. For the most part, this addresses issues in tests that were masked by the fact that they are currently expected to fail due to deficiencies in the existing scheduler.

See the commit messages for more information. 