### PR TITLE
fix: move revision info retrieval to the base `FlowCfg`

### DIFF
--- a/src/dvsim/flow/base.py
+++ b/src/dvsim/flow/base.py
@@ -26,6 +26,7 @@ from dvsim.utils import (
     rm_path,
     subst_wildcards,
 )
+from dvsim.utils.git import git_commit_hash
 
 if TYPE_CHECKING:
     from dvsim.job.deploy import Deploy
@@ -151,6 +152,11 @@ class FlowCfg(ABC):
         # after merging the hjson but before expansion, they can override
         # _expand and add the code at the start.
         self._expand()
+
+        # After initialisation & expansion, save some useful revision metadata
+        proj_root = Path(self.proj_root)
+        self.commit = git_commit_hash(path=proj_root, short=False)
+        self.commit_short = git_commit_hash(path=proj_root, short=True)
 
         # Construct the path variables after variable expansion.
         reports_dir = Path(self.scratch_base_path) / "reports"

--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -44,7 +44,7 @@ from dvsim.testplan import Testplan
 from dvsim.tool.utils import get_sim_tool_plugin
 from dvsim.utils import TS_FORMAT, rm_path
 from dvsim.utils.fs import relative_to
-from dvsim.utils.git import git_commit_hash, git_https_url_with_commit
+from dvsim.utils.git import git_https_url_with_commit
 
 __all__ = ("SimCfg",)
 
@@ -175,11 +175,6 @@ class SimCfg(FlowCfg):
         self.results_summary = OrderedDict()
 
         super().__init__(flow_cfg_file, hjson_data, args, mk_config)
-
-        # After initialisation & expansion, save some useful revision metadata
-        proj_root = Path(self.proj_root)
-        self.commit = git_commit_hash(path=proj_root, short=False)
-        self.commit_short = git_commit_hash(path=proj_root, short=True)
 
     def _expand(self) -> None:
         # Choose a wave format now. Note that this has to happen after parsing


### PR DESCRIPTION
In d6d53f6 (as part of #109), the logic to record the commit hash (and shortened version) was added to the sim flow, but in reality since it is used in the deploy it needs to be on every flow.

Move the computation of this information to the base `FlowCfg` object, after all expansion has taken place to fill in the `proj_root`. This should now work for the other flows (e.g. formal).

Closes #119.
Closes #133.