### PR TITLE
fix: use correct shorthand for 'Running' in the scheduler

### DIFF
--- a/src/dvsim/scheduler/core.py
+++ b/src/dvsim/scheduler/core.py
@@ -153,7 +153,7 @@ class Scheduler:
             width = len(str(self._total[target]))
             field_fmt = f"{{:0{width}d}}"
             self._msg_fmt = (
-                f"Q: {field_fmt}, D: {field_fmt}, P: {field_fmt}, "
+                f"Q: {field_fmt}, R: {field_fmt}, P: {field_fmt}, "
                 f"F: {field_fmt}, K: {field_fmt}, T: {field_fmt}"
             )
             msg = self._msg_fmt.format(0, 0, 0, 0, 0, self._total[target])


### PR DESCRIPTION
Fix a minor bug introduced by #129 (specifically 62258980740c8bc838ad0539d8ddc585af9b8a25), where the "Dispatched" job status was renamed to "Running". When I made this change, I remembered to replace the status header, but forgot to replace the hard-coded shorthand in the status bar messages in the core scheduler logic, because I later rewrote the scheduler / status bars to automatically derive these messages from the shorthand, and did not realize this issue would occur when merging the changes in stages.

This will be addressed by the new async status printers (#137), but should still be fixed in the scheduler in the meantime to prevent any confusion.

Closes #140.