### PR TITLE
Correct the type for Deploy.init

### DIFF
--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -25,8 +25,9 @@ from dvsim.utils import (
 )
 
 if TYPE_CHECKING:
-    from dvsim.flow.sim import SimCfg
+    from dvsim.flow.base import FlowCfg
     from dvsim.modes import BuildMode
+    from dvsim.sim.flow import SimCfg
 
 
 __all__ = (
@@ -59,7 +60,7 @@ class Deploy:
         """Get a string representation of the deployment object."""
         return pprint.pformat(self.__dict__) if log.isEnabledFor(log.VERBOSE) else self.full_name
 
-    def __init__(self, sim_cfg: "SimCfg") -> None:
+    def __init__(self, sim_cfg: "FlowCfg") -> None:
         """Initialise deployment object.
 
         Args:

--- a/src/dvsim/logging.py
+++ b/src/dvsim/logging.py
@@ -104,7 +104,7 @@ def _build_logger() -> DVSimLogger:
     # Log any unhandled exceptions
     _previous_excepthook = sys.excepthook
 
-    def _handle_exception(exc_type, exc_value, exc_tb):
+    def _handle_exception(exc_type, exc_value, exc_tb) -> None:
         logger.critical("Unhandled exception", exc_info=(exc_type, exc_value, exc_tb))
         _previous_excepthook(exc_type, exc_value, exc_tb)
 


### PR DESCRIPTION
The code in the constructor actually depends on lots of fields that are only in SimCfg, but we aren't really type-safe yet, so only find this out at runtime (when we try to do something other than a simulation).

Correct the type safety at the site where we actually create the Deploy object.