### PR TITLE
Move the "name" field up to FlowCfg

### DIFF
--- a/src/dvsim/flow/base.py
+++ b/src/dvsim/flow/base.py
@@ -74,6 +74,7 @@ class FlowCfg(ABC):
         self.interactive = args.interactive
 
         # Options set from hjson cfg.
+        self.name = ""
         self.project = ""
         self.scratch_path = ""
         self.scratch_base_path = ""

--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -140,7 +140,6 @@ class SimCfg(FlowCfg):
         self.sw_build_opts = []
         self.pass_patterns = []
         self.fail_patterns = []
-        self.name = ""
         self.variant = ""
         self.dut = ""
         self.tb = ""


### PR DESCRIPTION
Looking through hjson files quickly, I'm pretty certain that they always provide a name (which gets installed at runtime through _merge_hjson). Tell the type system about this.