### PR TITLE
refactor: Move tool name to FlowCfg

### DIFF
--- a/src/dvsim/flow/base.py
+++ b/src/dvsim/flow/base.py
@@ -84,6 +84,10 @@ class FlowCfg(ABC):
         self.scratch_path = ""
         self.scratch_base_path = ""
 
+        # The command line might specify the tool (with --tool). If not, we
+        # leave it as None (allowing an hjson file to populate it)
+        self.tool: str | None = args.tool
+
         # Add exports using 'exports' keyword - these are exported to the child
         # process' environment.
         self.exports = []

--- a/src/dvsim/flow/one_shot.py
+++ b/src/dvsim/flow/one_shot.py
@@ -25,7 +25,6 @@ class OneShotCfg(FlowCfg):
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config) -> None:
         # Options set from command line
-        self.tool = args.tool
         self.verbose = args.verbose
         self.flist_gen_cmd = ""
         self.flist_gen_opts = []

--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -117,6 +117,16 @@ class Deploy:
 
     def get_job_spec(self) -> "JobSpec":
         """Get the job spec for this deployment."""
+        # At this point, the configuration should have populated its tool field
+        # (either from a command line argument or a value in the hjson that was
+        # loaded. If not, we don't know what to do.
+        if self.sim_cfg.tool is None:
+            msg = (
+                "No tool selected in job configuration. It must either be "
+                "specified in the hjson or passed with the --tool argument."
+            )
+            raise RuntimeError(msg)
+
         return JobSpec(
             name=self.name,
             job_type=self.__class__.__name__,
@@ -950,6 +960,11 @@ class CovReport(Deploy):
             cov_report_path = Path(self.cov_report_txt)
             if self.dry_run or status != JobStatus.PASSED or not cov_report_path.exists():
                 return
+
+            # At this point, we have finished running a tool, so we know that
+            # self.sim_cfg.tool must have been set.
+            if self.sim_cfg.tool is None:
+                raise RuntimeError("sim_cfg.tool cannot be None now.")
 
             plugin = get_sim_tool_plugin(tool=self._typed_sim_cfg.tool)
 

--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -80,7 +80,6 @@ class SimCfg(FlowCfg):
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config) -> None:
         # Options set from command line
-        self.tool = args.tool
         self.build_opts = []
         self.build_opts.extend(args.build_opts)
         self.en_build_modes = args.build_modes.copy()


### PR DESCRIPTION
This value was always actually supplied (either directly in SimCfg or
through OneShotCfg). Move it to the base class and consume it in just
one place.

A specific type looks like there might be problems where we try to run
a job without having decided on the tool. The second instance of
this (in CovReport.post_finish) can definitely never happen, but the
example in Deploy.get_job_spec is less obvious to me, so I've put in a
runtime check.