### PR TITLE
refactor: Explicitly add proj_root to FlowCfg

### DIFF
--- a/src/dvsim/flow/base.py
+++ b/src/dvsim/flow/base.py
@@ -78,6 +78,7 @@ class FlowCfg(ABC):
         self.project = ""
         self.scratch_path = ""
         self.scratch_base_path = ""
+        self.proj_root = ""
 
         # Add exports using 'exports' keyword - these are exported to the child
         # process' environment.
@@ -153,6 +154,10 @@ class FlowCfg(ABC):
         # after merging the hjson but before expansion, they can override
         # _expand and add the code at the start.
         self._expand()
+
+        # Check that proj_root has indeed been defined in the hjson config file
+        if not self.proj_root:
+            raise RuntimeError("Config file did not define proj_root.")
 
         # After initialisation & expansion, save some useful revision metadata
         proj_root = Path(self.proj_root)

--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -138,7 +138,7 @@ class Deploy:
             ),
             workspace_cfg=WorkspaceConfig(
                 timestamp=self.sim_cfg.args.timestamp,
-                project_root=self.sim_cfg.proj_root,
+                project_root=Path(self.sim_cfg.proj_root),
                 scratch_root=Path(self.sim_cfg.scratch_root),
                 scratch_path=Path(self.sim_cfg.scratch_path),
             ),


### PR DESCRIPTION
This gets loaded up from the hjson file (and nothing will work if it's missing). This commit tweaks things so that we check the field has been loaded.

This will always have type str (because it gets loaded directly from an hjson file). Add an explicit cast to Path when calling the WorkspaceConfig constructor.
