### PR TITLE
Fix type of JobSpec.timeout_mins

### DIFF
--- a/src/dvsim/job/data.py
+++ b/src/dvsim/job/data.py
@@ -80,7 +80,7 @@ class JobSpec(BaseModel):
     """Wait for dependent jobs to pass before scheduling."""
     weight: int
     """Weight to apply to the scheduling priority."""
-    timeout_mins: int | None
+    timeout_mins: float | None
     """Timeout to apply to the launched job."""
 
     cmd: str
@@ -124,7 +124,7 @@ class JobSpec(BaseModel):
         return self.full_name
 
     @property
-    def timeout_secs(self) -> int | None:
+    def timeout_secs(self) -> float | None:
         """Returns the timeout applied to the launched job, in seconds."""
         return None if self.timeout_mins is None else self.timeout_mins * 60
 


### PR DESCRIPTION
This is set from Deploy.get_timeout_mins, which returns a float (probably the right type for this: "time out after 2.5 minutes" seems like a reasonable thing to say).