### PR TITLE
Add experimental Z01X support to sync with in-tree OpenTitan DVSim

### DIFF
--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -108,6 +108,14 @@ class Deploy:
         # Set class instance attributes.
         self._set_attrs()
 
+        # Mutate the attributes based on any tool plugins.
+        if self.sim_cfg.flow == "sim":
+            try:
+                plugin = get_sim_tool_plugin(self.sim_cfg.tool)
+                plugin.set_additional_attrs(self)
+            except NotImplementedError as e:
+                log.debug("Could not find sim tool for %s: %s", self.sim_cfg.tool, str(e))
+
         # Check if all attributes that are needed are set.
         self._check_attrs()
 

--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -100,7 +100,7 @@ class Deploy:
         self.dry_run = False
         self.flow_makefile = ""
         self.name = ""
-        self.exports: Iterable[Mapping[str, str]] = []
+        self.exports: list[dict[str, str]] = []
 
         # Declare attributes that need to be extracted from the HJSon cfg.
         self._define_attrs()

--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -463,6 +463,7 @@ class CompileSim(Deploy):
                 "build_dir": False,
                 "build_opts": False,
                 "post_build_cmds": False,
+                "post_build_opts": False,
             },
         )
 
@@ -567,6 +568,7 @@ class CompileOneShot(Deploy):
                 "build_log": False,
                 "build_timeout_mins": False,
                 "post_build_cmds": False,
+                "post_build_opts": False,
                 "pre_build_cmds": False,
                 # Report processing
                 "report_cmd": False,

--- a/src/dvsim/modes.py
+++ b/src/dvsim/modes.py
@@ -268,6 +268,7 @@ class BuildMode(Mode):
         self.post_build_cmds = []
         self.en_build_modes = []
         self.build_opts = []
+        self.post_build_opts = []
         self.build_timeout_mins = None
         self.pre_run_cmds = []
         self.post_run_cmds = []

--- a/src/dvsim/regression.py
+++ b/src/dvsim/regression.py
@@ -37,6 +37,7 @@ class Regression(Mode):
         self.pre_run_cmds = []
         self.post_run_cmds = []
         self.build_opts = []
+        self.post_build_opts = []
         self.run_opts = []
         super().__init__("regression", regdict)
 
@@ -110,6 +111,7 @@ class Regression(Mode):
                 # Merge the build and run cmds & opts from the sim modes
                 regression_obj.pre_build_cmds.extend(sim_mode_obj.pre_build_cmds)
                 regression_obj.post_build_cmds.extend(sim_mode_obj.post_build_cmds)
+                regression_obj.post_build_opts.extend(sim_mode_obj.post_build_opts)
                 regression_obj.build_opts.extend(sim_mode_obj.build_opts)
                 regression_obj.pre_run_cmds.extend(sim_mode_obj.pre_run_cmds)
                 regression_obj.post_run_cmds.extend(sim_mode_obj.post_run_cmds)
@@ -165,6 +167,7 @@ class Regression(Mode):
             if test.build_mode.name not in processed_build_modes:
                 test.build_mode.pre_build_cmds.extend(self.pre_build_cmds)
                 test.build_mode.post_build_cmds.extend(self.post_build_cmds)
+                test.build_mode.post_build_opts.extend(self.post_build_opts)
                 test.build_mode.build_opts.extend(self.build_opts)
                 processed_build_modes.append(test.build_mode.name)
             test.pre_run_cmds.extend(self.pre_run_cmds)

--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -131,6 +131,7 @@ class SimCfg(FlowCfg):
         self.flow_makefile = ""
         self.pre_build_cmds = []
         self.post_build_cmds = []
+        self.post_build_opts = []
         self.build_dir = ""
         self.pre_run_cmds = []
         self.post_run_cmds = []
@@ -280,6 +281,7 @@ class SimCfg(FlowCfg):
                 self.pre_build_cmds.extend(build_mode_obj.pre_build_cmds)
                 self.post_build_cmds.extend(build_mode_obj.post_build_cmds)
                 self.build_opts.extend(build_mode_obj.build_opts)
+                self.post_build_opts.extend(build_mode_obj.post_build_opts)
                 self.pre_run_cmds.extend(build_mode_obj.pre_run_cmds)
                 self.post_run_cmds.extend(build_mode_obj.post_run_cmds)
                 self.run_opts.extend(build_mode_obj.run_opts)
@@ -402,6 +404,7 @@ class SimCfg(FlowCfg):
             self.pre_build_cmds,
             self.post_build_cmds,
             self.build_opts,
+            self.post_build_opts,
             self.pre_run_cmds,
             self.post_run_cmds,
             self.run_opts,

--- a/src/dvsim/sim/tool/base.py
+++ b/src/dvsim/sim/tool/base.py
@@ -6,9 +6,12 @@
 
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from dvsim.sim.data import CoverageMetrics
+
+if TYPE_CHECKING:
+    from dvsim.job.deploy import Deploy
 
 __all__ = ("SimTool",)
 
@@ -79,6 +82,16 @@ class SimTool(Protocol):
 
         Returns:
             CoverageMetrics model.
+
+        """
+        ...
+
+    @staticmethod
+    def set_additional_attrs(deploy: "Deploy") -> None:
+        """Define any additional tool-specific attrs on the deploy object.
+
+        Args:
+            deploy: the deploy object to mutate.
 
         """
         ...

--- a/src/dvsim/sim/tool/vcs.py
+++ b/src/dvsim/sim/tool/vcs.py
@@ -7,8 +7,12 @@
 import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from dvsim.sim.data import CodeCoverageMetrics, CoverageMetrics
+
+if TYPE_CHECKING:
+    from dvsim.job.deploy import Deploy
 
 __all__ = ("VCS",)
 
@@ -132,3 +136,12 @@ class VCS:
                 fsm=raw_metrics.get("fsm"),
             ),
         )
+
+    @staticmethod
+    def set_additional_attrs(deploy: "Deploy") -> None:
+        """Define any additional tool-specific attrs on the deploy object.
+
+        Args:
+            deploy: the deploy object to mutate.
+
+        """

--- a/src/dvsim/sim/tool/xcelium.py
+++ b/src/dvsim/sim/tool/xcelium.py
@@ -8,8 +8,12 @@ import re
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from dvsim.sim.data import CodeCoverageMetrics, CoverageMetrics
+
+if TYPE_CHECKING:
+    from dvsim.job.deploy import Deploy
 
 __all__ = ("Xcelium",)
 
@@ -157,3 +161,12 @@ class Xcelium:
                 fsm=raw_metrics.get("fsm"),
             ),
         )
+
+    @staticmethod
+    def set_additional_attrs(deploy: "Deploy") -> None:
+        """Define any additional tool-specific attrs on the deploy object.
+
+        Args:
+            deploy: the deploy object to mutate.
+
+        """

--- a/src/dvsim/sim/tool/z01x.py
+++ b/src/dvsim/sim/tool/z01x.py
@@ -1,0 +1,33 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EDA tool plugin providing Z01X support to DVSim."""
+
+from typing import TYPE_CHECKING
+
+from dvsim.sim.tool.vcs import VCS
+
+if TYPE_CHECKING:
+    from dvsim.job.deploy import Deploy
+
+__all__ = ("Z01X",)
+
+
+class Z01X(VCS):
+    """Implement Z01X tool support."""
+
+    @staticmethod
+    def set_additional_attrs(deploy: "Deploy") -> None:
+        """Define any additional tool-specific attrs on the deploy object.
+
+        Args:
+            deploy: the deploy object to mutate.
+
+        """
+        # TODO: when circular import issues are resolved, this can be a check of
+        # `isinstance(deploy, RunTest)` and we don't need the type ignores here.
+        if deploy.target == "run":
+            sim_run_opts = " ".join(opt.strip() for opt in deploy.run_opts)  # type: ignore[reportAttributeAccessIssue]
+            deploy.exports.append({"sim_run_opts": sim_run_opts})
+            deploy.run_opts = list(getattr(deploy.sim_cfg, "run_opts_fi_sim", ()))  # type: ignore[reportAttributeAccessIssue]

--- a/src/dvsim/test.py
+++ b/src/dvsim/test.py
@@ -121,6 +121,7 @@ class Test(RunMode):
         global_pre_build_cmds,
         global_post_build_cmds,
         global_build_opts,
+        global_post_build_opts,
         global_pre_run_cmds,
         global_post_run_cmds,
         global_run_opts,
@@ -133,6 +134,7 @@ class Test(RunMode):
                 test.build_mode.pre_build_cmds.extend(global_pre_build_cmds)
                 test.build_mode.post_build_cmds.extend(global_post_build_cmds)
                 test.build_mode.build_opts.extend(global_build_opts)
+                test.build_mode.post_build_opts.extend(global_post_build_opts)
                 processed_build_modes.add(test.build_mode.name)
             test.pre_run_cmds.extend(global_pre_run_cmds)
             test.post_run_cmds.extend(global_post_run_cmds)

--- a/src/dvsim/tool/utils.py
+++ b/src/dvsim/tool/utils.py
@@ -8,12 +8,14 @@ from dvsim.logging import log
 from dvsim.sim.tool.base import SimTool
 from dvsim.sim.tool.vcs import VCS
 from dvsim.sim.tool.xcelium import Xcelium
+from dvsim.sim.tool.z01x import Z01X
 
 __all__ = ("get_sim_tool_plugin",)
 
 _SUPPORTED_SIM_TOOLS = {
     "vcs": VCS,
     "xcelium": Xcelium,
+    "z01x": Z01X,
 }
 
 

--- a/tests/job/test_deploy.py
+++ b/tests/job/test_deploy.py
@@ -26,6 +26,8 @@ class FakeCliArgs:
 class FakeSimCfg:
     """Fake sim configuration."""
 
+    flow = "fake"
+
     def __init__(self) -> None:
         """Initialise fake sim configuration."""
         self.name = "flow_name"

--- a/tests/job/test_deploy.py
+++ b/tests/job/test_deploy.py
@@ -69,6 +69,7 @@ class FakeBuildMode:
         self.build_timeout_mins = 500
         self.build_mode = "build_mode"
         self.build_opts = ["-b path/here", '-a "Quoted"']
+        self.post_build_opts = ["E"]
 
 
 def _build_compile_sim(
@@ -122,6 +123,7 @@ class TestCompileSim:
                 "build_dir=build/dir "
                 "build_opts='-b path/here -a \"Quoted\"' "
                 "post_build_cmds='C && D' "
+                "post_build_opts=E "
                 "pre_build_cmds='A && B' "
                 "proj_root=/project "
                 "sv_flist_gen_cmd=gen_cmd "
@@ -136,6 +138,7 @@ class TestCompileSim:
                 "build_dir=build/dir "
                 "build_opts='-b path/here -a \"Quoted\"' "
                 "post_build_cmds='C && D' "
+                "post_build_opts=E "
                 "pre_build_cmds='A && B' "
                 "proj_root=/project "
                 "sv_flist_gen_cmd=gen_cmd "


### PR DESCRIPTION
Since DVSim was pulled out and separated from OpenTitan, one additional PR has been made that has modified the operation of DVSim: https://github.com/lowRISC/opentitan/pull/28782

This PR aims to replicate the changes from that PR, refactored to fit out-of-tree DVSim. Two of the commits specifically implement the same functionality as from that PR - the other commits are related fixes not in the original PR.
1. For the second commit, almost nothing is changed, except for fixes to keep the `Deploy` tests passing.
2. For the fourth commit, the modification to `RunTest` is changed to now instead add `Z01X` as a separate simulation tool plugin. This way, we can inherit all of the relevant plugin functionality of VCS, whilst decoupling the Z01X-specific logic from the Deploy core itself. To do this, a generic mechanism is introduced to allow tools to mutate deploy objects after all initialization and expansion.