### PR TITLE
Add Z01X sim tool runtime/simtime support

### DIFF
--- a/src/dvsim/launcher/base.py
+++ b/src/dvsim/launcher/base.py
@@ -340,7 +340,7 @@ class Launcher(ABC):
             plugin = get_sim_tool_plugin(tool=self.job_spec.tool.name)
 
             try:
-                time, unit = plugin.get_job_runtime(log_text=lines)
+                time, unit = plugin.get_job_runtime(self.job_spec, log_text=lines)
 
             except RuntimeError as e:
                 log.warning(
@@ -353,7 +353,7 @@ class Launcher(ABC):
 
         if self.job_spec.job_type == "RunTest":
             try:
-                time, unit = plugin.get_simulated_time(log_text=lines)
+                time, unit = plugin.get_simulated_time(self.job_spec, log_text=lines)
                 self.simulated_time.set(time, unit)
             except RuntimeError as e:
                 log.debug("%s: %s", self.job_spec.full_name, str(e))

--- a/src/dvsim/runtime/backend.py
+++ b/src/dvsim/runtime/backend.py
@@ -355,7 +355,7 @@ class LogResults:
 
         runtime = None
         try:
-            time, unit = plugin.get_job_runtime(log_text=lines)
+            time, unit = plugin.get_job_runtime(self.spec, log_text=lines)
             runtime = JobTime(time, unit)
         except RuntimeError as e:
             log.warning("%s: %s", self.spec.full_name, str(e))
@@ -363,7 +363,7 @@ class LogResults:
         simulated_time = None
         if self.spec.job_type == "RunTest":
             try:
-                time, unit = plugin.get_simulated_time(log_text=lines)
+                time, unit = plugin.get_simulated_time(self.spec, log_text=lines)
                 simulated_time = JobTime(time, unit)
             except RuntimeError as e:
                 log.debug("%s: %s", self.spec.full_name, str(e))

--- a/src/dvsim/sim/tool/base.py
+++ b/src/dvsim/sim/tool/base.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from dvsim.job.data import JobSpec
 from dvsim.sim.data import CoverageMetrics
 
 if TYPE_CHECKING:
@@ -34,7 +35,7 @@ class SimTool(Protocol):
         ...
 
     @staticmethod
-    def get_job_runtime(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_job_runtime(job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the job runtime (wall clock time) along with its units.
 
         EDA tools indicate how long the job ran in terms of CPU time in the log
@@ -43,6 +44,7 @@ class SimTool(Protocol):
         units as a tuple.
 
         Args:
+            job: The job that was run.
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
@@ -55,7 +57,7 @@ class SimTool(Protocol):
         ...
 
     @staticmethod
-    def get_simulated_time(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_simulated_time(job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the simulated time along with its units.
 
         EDA tools indicate how long the design was simulated for in the log file.
@@ -64,6 +66,7 @@ class SimTool(Protocol):
         units (typically, pico|nano|micro|milliseconds) as a tuple.
 
         Args:
+            job: The job that was run
             log_text: is the job's log file contents as a list of lines.
 
         Returns:

--- a/src/dvsim/sim/tool/base.py
+++ b/src/dvsim/sim/tool/base.py
@@ -44,10 +44,12 @@ class SimTool(Protocol):
 
         Args:
             log_text: is the job's log file contents as a list of lines.
-            tool: is the EDA tool used to run the job.
 
         Returns:
             a tuple of (runtime, units).
+
+        Raises:
+            RuntimeError: exception if the search pattern is not found.
 
         """
         ...
@@ -65,7 +67,7 @@ class SimTool(Protocol):
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
-            the simulated, units as a tuple.
+            a tuple of (simulated time, units).
 
         Raises:
             RuntimeError: exception if the search pattern is not found.

--- a/src/dvsim/sim/tool/vcs.py
+++ b/src/dvsim/sim/tool/vcs.py
@@ -52,7 +52,7 @@ class VCS:
 
         # If we reached here, then we were unable to extract the coverage.
         msg = f"Coverage data not found in {cov_report_path}!"
-        raise SyntaxError(msg)
+        raise RuntimeError(msg)
 
     @staticmethod
     def get_job_runtime(log_text: Sequence[str]) -> tuple[float, str]:

--- a/src/dvsim/sim/tool/vcs.py
+++ b/src/dvsim/sim/tool/vcs.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from dvsim.job.data import JobSpec
 from dvsim.sim.data import CodeCoverageMetrics, CoverageMetrics
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ class VCS:
         raise RuntimeError(msg)
 
     @staticmethod
-    def get_job_runtime(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_job_runtime(_job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the job runtime (wall clock time) along with its units.
 
         EDA tools indicate how long the job ran in terms of CPU time in the log
@@ -64,6 +65,7 @@ class VCS:
         units as a tuple.
 
         Args:
+            job: The job that was run.
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
@@ -82,7 +84,7 @@ class VCS:
         raise RuntimeError(msg)
 
     @staticmethod
-    def get_simulated_time(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_simulated_time(_job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the simulated time along with its units.
 
         EDA tools indicate how long the design was simulated for in the log file.
@@ -91,6 +93,7 @@ class VCS:
         units (typically, pico|nano|micro|milliseconds) as a tuple.
 
         Args:
+            job: The job that was run
             log_text: is the job's log file contents as a list of lines.
 
         Returns:

--- a/src/dvsim/sim/tool/vcs.py
+++ b/src/dvsim/sim/tool/vcs.py
@@ -65,10 +65,12 @@ class VCS:
 
         Args:
             log_text: is the job's log file contents as a list of lines.
-            tool: is the EDA tool used to run the job.
 
         Returns:
             a tuple of (runtime, units).
+
+        Raises:
+            RuntimeError: exception if the search pattern is not found.
 
         """
         pattern = r"^CPU [tT]ime:\s*(\d+\.?\d*?)\s*(seconds|minutes|hours).*$"
@@ -92,7 +94,7 @@ class VCS:
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
-            the simulated, units as a tuple.
+            a tuple of (simulated time, units).
 
         Raises:
             RuntimeError: exception if the search pattern is not found.

--- a/src/dvsim/sim/tool/xcelium.py
+++ b/src/dvsim/sim/tool/xcelium.py
@@ -93,10 +93,12 @@ class Xcelium:
 
         Args:
             log_text: is the job's log file contents as a list of lines.
-            tool: is the EDA tool used to run the job.
 
         Returns:
             a tuple of (runtime, units).
+
+        Raises:
+            RuntimeError: exception if the search pattern is not found.
 
         """
         pattern = r"^TOOL:\s*xrun.*: Exiting on .*\(total:\s*(\d+):(\d+):(\d+)\)\s*$"
@@ -121,7 +123,7 @@ class Xcelium:
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
-            the simulated, units as a tuple.
+            a tuple of (simulated time, units).
 
         Raises:
             RuntimeError: exception if the search pattern is not found.

--- a/src/dvsim/sim/tool/xcelium.py
+++ b/src/dvsim/sim/tool/xcelium.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from dvsim.job.data import JobSpec
 from dvsim.sim.data import CodeCoverageMetrics, CoverageMetrics
 
 if TYPE_CHECKING:
@@ -83,7 +84,7 @@ class Xcelium:
         raise RuntimeError(msg)
 
     @staticmethod
-    def get_job_runtime(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_job_runtime(_job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the job runtime (wall clock time) along with its units.
 
         EDA tools indicate how long the job ran in terms of CPU time in the log
@@ -92,6 +93,7 @@ class Xcelium:
         units as a tuple.
 
         Args:
+            job: The job that was run.
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
@@ -111,7 +113,7 @@ class Xcelium:
         raise RuntimeError(msg)
 
     @staticmethod
-    def get_simulated_time(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_simulated_time(_job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the simulated time along with its units.
 
         EDA tools indicate how long the design was simulated for in the log file.
@@ -120,6 +122,7 @@ class Xcelium:
         units (typically, pico|nano|micro|milliseconds) as a tuple.
 
         Args:
+            job: The job that was run
             log_text: is the job's log file contents as a list of lines.
 
         Returns:

--- a/src/dvsim/sim/tool/xcelium.py
+++ b/src/dvsim/sim/tool/xcelium.py
@@ -80,7 +80,7 @@ class Xcelium:
 
         # If we reached here, then we were unable to extract the coverage.
         msg = f"Coverage data not found in {buf.name}!"
-        raise SyntaxError(msg)
+        raise RuntimeError(msg)
 
     @staticmethod
     def get_job_runtime(log_text: Sequence[str]) -> tuple[float, str]:

--- a/src/dvsim/sim/tool/z01x.py
+++ b/src/dvsim/sim/tool/z01x.py
@@ -4,6 +4,7 @@
 
 """EDA tool plugin providing Z01X support to DVSim."""
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from dvsim.sim.tool.vcs import VCS
@@ -16,6 +17,92 @@ __all__ = ("Z01X",)
 
 class Z01X(VCS):
     """Implement Z01X tool support."""
+
+    RUNTIME_COL = 2
+    SIMTIME_COL = 3
+    REQUIRED_COLS = max(RUNTIME_COL, SIMTIME_COL) + 1
+
+    @staticmethod
+    def _get_execution_summary(log_text: Sequence[str]) -> list[str]:
+        summary_start: int | None = None
+        summary_end: int | None = None
+        for i, line in reversed(list(enumerate(log_text))):
+            if line.strip() == "Execution Summary":
+                summary_start = i
+                break
+            if summary_end is None and set(line) == set("="):
+                summary_end = i
+        if summary_start is None:
+            msg = f"Execution summary not found in log (start={summary_start}, end={summary_end})"
+            raise RuntimeError(msg)
+
+        for line in reversed(log_text[summary_start + 1 : summary_end]):
+            if "|" not in line:
+                continue
+            return [c.strip() for c in line.split("|")]
+
+        msg = f"Summary table not found in log (start={summary_start}, end={summary_end})"
+        raise RuntimeError(msg)
+
+    @staticmethod
+    def get_job_runtime(log_text: Sequence[str]) -> tuple[float, str]:
+        """Return the job runtime (wall clock time) along with its units.
+
+        EDA tools indicate how long the job ran in terms of CPU time in the log
+        file. This method invokes the tool specific method which parses the log
+        text and returns the runtime as a floating point value followed by its
+        units as a tuple.
+
+        Args:
+            log_text: is the job's log file contents as a list of lines.
+
+        Returns:
+            a tuple of (runtime, units).
+
+        Raises:
+            RuntimeError: exception if the search pattern is not found.
+
+        """
+        summary_totals = Z01X._get_execution_summary(log_text)
+        if len(summary_totals) < Z01X.REQUIRED_COLS:
+            msg = f"Summary table contained less columns ({len(summary_totals)}) than expected"
+            raise RuntimeError(msg)
+
+        try:  # Quite fragile: columns are hardcoded.
+            return float(summary_totals[Z01X.RUNTIME_COL]), "s"
+        except ValueError as e:
+            msg = f"Found invalid runtime value '{summary_totals[Z01X.RUNTIME_COL]}'"
+            raise RuntimeError(msg) from e
+
+    @staticmethod
+    def get_simulated_time(log_text: Sequence[str]) -> tuple[float, str]:
+        """Return the simulated time along with its units.
+
+        EDA tools indicate how long the design was simulated for in the log file.
+        This method invokes the tool specific method which parses the log text and
+        returns the simulated time as a floating point value followed by its
+        units (typically, pico|nano|micro|milliseconds) as a tuple.
+
+        Args:
+            log_text: is the job's log file contents as a list of lines.
+
+        Returns:
+            a tuple of (simulated time, units).
+
+        Raises:
+            RuntimeError: exception if the search pattern is not found.
+
+        """
+        summary_totals = Z01X._get_execution_summary(log_text)
+        if len(summary_totals) < Z01X.REQUIRED_COLS:
+            msg = f"Summary table contained less columns ({len(summary_totals)}) than expected"
+            raise RuntimeError(msg)
+
+        try:  # Quite fragile: columns are hardcoded.
+            return float(summary_totals[Z01X.SIMTIME_COL]), "s"
+        except ValueError as e:
+            msg = f"Found invalid simulated time value '{summary_totals[Z01X.SIMTIME_COL]}'"
+            raise RuntimeError(msg) from e
 
     @staticmethod
     def set_additional_attrs(deploy: "Deploy") -> None:

--- a/src/dvsim/sim/tool/z01x.py
+++ b/src/dvsim/sim/tool/z01x.py
@@ -7,6 +7,7 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from dvsim.job.data import JobSpec
 from dvsim.sim.tool.vcs import VCS
 
 if TYPE_CHECKING:
@@ -45,7 +46,7 @@ class Z01X(VCS):
         raise RuntimeError(msg)
 
     @staticmethod
-    def get_job_runtime(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_job_runtime(job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the job runtime (wall clock time) along with its units.
 
         EDA tools indicate how long the job ran in terms of CPU time in the log
@@ -54,6 +55,7 @@ class Z01X(VCS):
         units as a tuple.
 
         Args:
+            job: The job that was run.
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
@@ -63,6 +65,9 @@ class Z01X(VCS):
             RuntimeError: exception if the search pattern is not found.
 
         """
+        if job.target != "run":
+            return VCS.get_job_runtime(job, log_text)
+
         summary_totals = Z01X._get_execution_summary(log_text)
         if len(summary_totals) < Z01X.REQUIRED_COLS:
             msg = f"Summary table contained less columns ({len(summary_totals)}) than expected"
@@ -75,7 +80,7 @@ class Z01X(VCS):
             raise RuntimeError(msg) from e
 
     @staticmethod
-    def get_simulated_time(log_text: Sequence[str]) -> tuple[float, str]:
+    def get_simulated_time(job: JobSpec, log_text: Sequence[str]) -> tuple[float, str]:
         """Return the simulated time along with its units.
 
         EDA tools indicate how long the design was simulated for in the log file.
@@ -84,6 +89,7 @@ class Z01X(VCS):
         units (typically, pico|nano|micro|milliseconds) as a tuple.
 
         Args:
+            job: The job that was run
             log_text: is the job's log file contents as a list of lines.
 
         Returns:
@@ -93,6 +99,9 @@ class Z01X(VCS):
             RuntimeError: exception if the search pattern is not found.
 
         """
+        if job.target != "run":
+            return VCS.get_job_runtime(job, log_text)
+
         summary_totals = Z01X._get_execution_summary(log_text)
         if len(summary_totals) < Z01X.REQUIRED_COLS:
             msg = f"Summary table contained less columns ({len(summary_totals)}) than expected"

--- a/tests/tool/test_vcs.py
+++ b/tests/tool/test_vcs.py
@@ -5,11 +5,13 @@
 """Test the VCS tool plugin."""
 
 from collections.abc import Sequence
+from pathlib import Path
 
 import pytest
 from hamcrest import assert_that, equal_to
 
 from dvsim.tool.utils import get_sim_tool_plugin
+from tests.test_scheduler import job_spec_factory
 
 __all__ = ("TestVCSToolPlugin",)
 
@@ -40,16 +42,18 @@ class TestVCSToolPlugin:
             (5.5134, "PS"),
         ],
     )
-    def test_get_simulated_time(time: int, units: str) -> None:
+    def test_get_simulated_time(tmp_path: Path, time: int, units: str) -> None:
         """Test that sim plugins can be retrieved correctly."""
         plugin = get_sim_tool_plugin("vcs")
+        mock_job_spec = job_spec_factory(tmp_path)
 
         assert_that(
             plugin.get_simulated_time(
+                mock_job_spec,
                 log_text=fake_log(
                     sim_time=time,
                     sim_time_units=units,
-                )
+                ),
             ),
             equal_to((time, units.lower())),
         )


### PR DESCRIPTION
The format used for parsing the runtime and simulation time that is reported differs during the `run` phase for this simulation tool. Add the minimal relevant (somewhat fragile) logic to parse these values out so that they display correctly.

Also resolve some other miscellaneous cleanup surrounding the sim tools - see the commit messages for more information.