### PR TITLE
Action version bumps to resolve warnings about upcoming Node.js 20 EOL in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Nix Format Check
         run: nix fmt -- . --check
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Install the project
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required so we can lint commit messages.
 
@@ -91,7 +91,7 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
     steps:
 
       - name: Setup | Download dist artifacts from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         id: artifact-download
         with:
           name: distribution-artifacts
@@ -180,7 +180,7 @@ jobs:
     steps:
 
       - name: Setup | Download dist artifacts from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         id: artifact-download
         with:
           name: distribution-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: lowrisc/ci-actions/ca-token@v1
 
       - name: Setup | Checkout Repository at PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.get-token.outputs.token }}
           ref: ${{ github.ref_name }}
@@ -97,7 +97,7 @@ jobs:
     steps:
 
       - name: Setup | Checkout Repository at newly tagged release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Can't checkout at the new tag, we need to match one of the configured
           # semantic_release.branches for the publish-action to proceed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           tag: ${{ needs.release.outputs.tag }}
 
       - name: Upload | Distribution artifacts to blob store for follow-up jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: distribution-artifacts
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup | Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Setup | Install Python + the python project with release dependencies
         run: |
@@ -107,7 +107,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup | Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Setup | Install Python + the python project with build dependencies
         run: |


### PR DESCRIPTION
Bump all actions that were still using node20 to newer major versions that use node24. For each action I've checked the breaking changes and migration guidance in the release notes, and it appears that no breaking changes impact our use cases.

For any updated actions that support [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), I've pinned the specific immutable release. This would also mean pinning a specific SHA for the commonplace `checkout`, `upload-artifact` and `download-artifact` supported by GitHub, so for now these remain pinned only to major versions whilst no immutable releases exist. There are issues open on these actions upstream to support moving to immutable releases.