### PR TITLE
Improve failure bucket presentation in block reports

### DIFF
--- a/src/dvsim/sim/report.py
+++ b/src/dvsim/sim/report.py
@@ -111,9 +111,16 @@ class HtmlReportRenderer:
             file_name = results.block.variant_name()
             log.debug("Generating HTML report for '%s'", file_name)
             block_file = f"{file_name}.html"
+            sorted_buckets = dict(
+                sorted(results.failed_jobs.buckets.items(), key=lambda kv: len(kv[1]), reverse=True)
+            )
             artifacts[block_file] = render_template(
                 path="reports/block_report.html",
-                data={"results": results, "version": summary.version},
+                data={
+                    "results": results,
+                    "failed_jobs": sorted_buckets,
+                    "version": summary.version,
+                },
             )
             if outdir is not None:
                 (outdir / block_file).write_text(artifacts[block_file])

--- a/src/dvsim/templates/reports/block_report.html
+++ b/src/dvsim/templates/reports/block_report.html
@@ -11,7 +11,6 @@
 {% set timestamp = results.timestamp %}
 {% set stages = results.stages %}
 {% set coverage = results.coverage %}
-{% set failed_jobs = results.failed_jobs %}
 {% block content %}
 <div class="container-md">
     <div class="row">
@@ -204,7 +203,7 @@
     </div>
     {% endif %}
 
-    {% if failed_jobs.buckets %}
+    {% if failed_jobs %}
     <div class="row py-3">
         <div class="col">
             <h3>Error Messages</h3>
@@ -219,7 +218,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                {% for msg, job_list in failed_jobs.buckets.items() %}
+                {% for msg, job_list in failed_jobs.items() %}
                     <tr class="table-primary">
                         <td colspan=5>{{ msg }}</td>
                     </tr>

--- a/src/dvsim/templates/reports/block_report.html
+++ b/src/dvsim/templates/reports/block_report.html
@@ -220,7 +220,8 @@
                 <tbody>
                 {% for msg, job_list in failed_jobs.items() %}
                     <tr class="table-primary">
-                        <td colspan=5>{{ msg }}</td>
+                        <td colspan=4>{{ msg }}</td>
+                        <td><b>{{ job_list|length }} test run{{ "s" if job_list|length > 1 else "" }}</b></td>
                     </tr>
                     {% for job in job_list %}
                     <tr>

--- a/src/dvsim/templates/reports/block_report.html
+++ b/src/dvsim/templates/reports/block_report.html
@@ -229,8 +229,8 @@
                         <td>{{ job.seed }}</td>
                         <td>{{ job.line }}</td>
                         <td>
-                        {% for line in job.log_context %}
-                            <div>{{ line }}</div>
+                        {% for context_line in job.log_context %}
+                            <div>{{ context_line }}</div>
                         {% endfor %}
                         </td>
                     </tr>


### PR DESCRIPTION
Sort the buckets so the most common failure mode appears first, and also display some metadata listing the total number of failures in each bucket. This should make the generated block report more useful for finding important issues.