### PR TITLE
Backend time/failure reporting fixes for timeouts of local jobs

### DIFF
--- a/src/dvsim/runtime/backend.py
+++ b/src/dvsim/runtime/backend.py
@@ -218,11 +218,21 @@ class RuntimeBackend(ABC):
         self._make_job_output_directory(job)
 
     def _finish_job(
-        self, handle: JobHandle, exit_code: int, runtime: float | None
+        self, handle: JobHandle, exit_code: int | None, runtime: float | None
     ) -> tuple[JobStatus, JobStatusInfo | None]:
         """Determine the outcome of a job that ran to completion, and parse extra log info.
 
         Updates the handle with any extracted job runtime & simulation time info.
+
+        Args:
+            handle: The handle to the job that finished.
+            exit_code: The exit code if the job finished gracefully, or None if it was terminated.
+            runtime: The amount of time taken to complete the job, if known.
+
+        Returns:
+            A tuple containing the final job status and optionally an additional context/reason
+            object describing the job completion.
+
         """
         if handle.spec.dry_run:
             return JobStatus.PASSED, None
@@ -241,6 +251,11 @@ class RuntimeBackend(ABC):
             handle.simulated_time.set(*simulated_time.get())
 
         # Determine the final status from the logs and exit code.
+        if exit_code is None:
+            return JobStatus.KILLED, JobStatusInfo(
+                message=f"Job timed out after {handle.spec.timeout_mins} minutes"
+            )
+
         status, reason = log_results.get_status_from_logs()
         if status is not None:
             return status, reason

--- a/src/dvsim/runtime/local.py
+++ b/src/dvsim/runtime/local.py
@@ -109,19 +109,17 @@ class LocalRuntimeBackend(RuntimeBackend):
         ]
         status = JobStatus.KILLED
         reason = None
+        exit_code = None
 
         try:
             exit_code = await asyncio.wait_for(
                 handle.process.wait(), timeout=handle.spec.timeout_secs
             )
-            runtime = time.monotonic() - handle.start_time
-            status, reason = self._finish_job(handle, exit_code, runtime)
         except asyncio.TimeoutError:
             await self._kill_job(handle)
-            status = JobStatus.KILLED
-            timeout_message = f"Job timed out after {handle.spec.timeout_mins} minutes"
-            reason = JobStatusInfo(message=timeout_message)
         finally:
+            runtime = time.monotonic() - handle.start_time
+
             # Explicitly cancel reader tasks and wait for them to finish before closing the log
             # file. We first give them a second to finish naturally to reduce log loss.
             with contextlib.suppress(asyncio.TimeoutError):
@@ -130,6 +128,8 @@ class LocalRuntimeBackend(RuntimeBackend):
                 if not task.done():
                     task.cancel()
             await asyncio.gather(*reader_tasks, return_exceptions=True)
+
+            status, reason = self._finish_job(handle, exit_code, runtime)
 
             if handle.log_file:
                 handle.log_file.close()

--- a/src/dvsim/runtime/local.py
+++ b/src/dvsim/runtime/local.py
@@ -322,7 +322,6 @@ class LocalRuntimeBackend(RuntimeBackend):
             return
 
         if proc.returncode is None:
-            handle.kill_requested = True
             try:
                 self._send_kill_signal(proc, signal.SIGTERM)
             except ProcessLookupError:
@@ -366,6 +365,7 @@ class LocalRuntimeBackend(RuntimeBackend):
                 msg = f"Local backend expected handle of type LocalJobHandle, not `{type(handle)}`."
                 raise TypeError(msg)
             if handle.process and not handle.kill_requested and handle.process.returncode is None:
+                handle.kill_requested = True
                 tasks.append(asyncio.create_task(self._kill_job(handle)))
 
         if tasks:


### PR DESCRIPTION
This PR fixes two bugs in the runtime backends:
* One issue is inherited from the original launchers (whilst trying to maintain their behaviour), where any jobs that timeout do not report the DVSim-maintained runtime in the final results. We now always make sure to go through this path in the code, and make some refactoring improvements at the same time to centralize the timeout reporting logic to to reduce the potential for inconsistent failure messages in the future with more backends.
* The other is a small bug introduced in the `LocalRuntimeBackend`, where the error message that was being reported was not correct ("Job killed!" instead of "Job timed out after X minutes").

See the commit messages for more info.

Example change:
```diff
 ### Test Results
 
 |  Stage  |  Name  | Tests                  |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
 |:-------:|:------:|:-----------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
-|         |        | ate_bootstrap_disjoint |      0.000s       |     0.000us      |     0     |    1    |   0.00 %    |
+|         |        | ate_bootstrap_disjoint |      6.007s       |     0.000us      |     0     |    1    |   0.00 %    |
 |         |        | **TOTAL**              |                   |                  |     0     |    1    |   0.00 %    |
 |         |        | **TOTAL**              |                   |                  |     0     |    1    |   0.00 %    |
 
 ## Coverage Results
 ### [Coverage Dashboard](/opentitan/scratch/master/chip_earlgrey_asic-sim-vcs/cov_report/dashboard.html)
 
 ## Failure Buckets
-* `Job killed!` has 1 failure:
+* `Job timed out after * minutes` has 1 failure:
     * Test ate_bootstrap_disjoint has 1 failure.
         * 0.ate_bootstrap_disjoint.58088541501576402788773390777979312745996416705647052408538425973305215300754\
           Log /opentitan/scratch/master/chip_earlgrey_asic-sim-vcs/0.ate_bootstrap_disjoint/latest/run.log
```