### PR TITLE
Fix extraneous underscore inserted after block names without variants

### DIFF
--- a/src/dvsim/job/deploy.py
+++ b/src/dvsim/job/deploy.py
@@ -82,7 +82,7 @@ class Deploy:
         if not (isinstance(self._variant, str) or self._variant is None):
             raise TypeError("Unexpected type for variant")
 
-        self._variant_suffix = f"_{self._variant}" if self._variant is not None else ""
+        self._variant_suffix = f"_{self._variant}" if self._variant else ""
 
         # A list of jobs on which this job depends.
         self.dependencies = []


### PR DESCRIPTION
This PR is the second of a series of PRs to introduce instrumentation reporting to DVSim.

This PR resolves a minor bug accidentally introduced in a11da78e6220aa14ccf036538d0b47025e93ad34 by #146. For blocks without variants (e.g. "chip", "uart" or "i2c"), they started to be suffixed with an extraneous underscore (e.g. "chip_", "uart_" or "i2c_"). This led to full expanded job names like e.g. 
```
uart_:0.uart_smoke.61334166618218684041827000266315431097756579266692204924182277768109975504045
```
where the additional underscore before the colon is not desired.

If all the flows were well-typed to use a `None` variant then this change makes sense (to somehow allow the non-sensical empty string `''` variant), but for now let's also catch this empty string case as is the default for some flows. Ideally further refactoring in the future would ensure that all variant names go through some definition like `IPMeta.variant_name`: https://github.com/lowRISC/dvsim/blob/71c363c720158b9f6a27524dc0bd89e5da45c0d9/src/dvsim/report/data.py#L36-L38

But until the flows & deploys are refactored further, we should defensively detect this empty string case.