### PR TITLE
Instrumentation refactoring cleanups & UX improvements

### DIFF
--- a/src/dvsim/cli/run.py
+++ b/src/dvsim/cli/run.py
@@ -833,7 +833,7 @@ def parse_args(argv: list[str] | None = None):
         dest="instrumentation",
         nargs="+",
         default=[],
-        choices=InstrumentationFactory.options(),
+        choices=["all", *InstrumentationFactory.options()],
         help="Enable scheduler instrumentation (can specify multiple types).",
     )
 
@@ -986,7 +986,12 @@ def main(argv: list[str] | None = None) -> None:
 
     # Configure scheduler instrumentation
     if args.instrumentation:
-        set_instrumentation(InstrumentationFactory.create(args.instrumentation))
+        instrumentations = (
+            InstrumentationFactory.options()
+            if "all" in args.instrumentation
+            else args.instrumentation
+        )
+        set_instrumentation(InstrumentationFactory.create(instrumentations))
 
     # Build infrastructure from hjson file and create the list of items to
     # be deployed.

--- a/src/dvsim/instrumentation/compute.py
+++ b/src/dvsim/instrumentation/compute.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-"""DVSim scheduler instrumentation for system resource usage."""
+"""DVSim scheduler instrumentation for system compute resource usage."""
 
 import os
 import threading
@@ -12,11 +12,11 @@ from collections.abc import Mapping
 import psutil
 
 from dvsim.instrumentation.base import SchedulerInstrumentation
-from dvsim.instrumentation.records import JobResourceMetrics, SchedulerResourceMetrics
+from dvsim.instrumentation.records import JobComputeMetrics, SchedulerComputeMetrics
 from dvsim.job.data import JobSpec
 from dvsim.job.status import JobStatus
 
-__all__ = ("ResourceInstrumentation",)
+__all__ = ("ComputeInstrumentation",)
 
 
 class JobResourceAggregate:
@@ -44,21 +44,21 @@ class JobResourceAggregate:
         self.max_rss = max(self.max_rss, rss)
         self.sum_cpu += cpu
 
-    def finalize(self) -> JobResourceMetrics:
+    def finalize(self) -> JobComputeMetrics:
         """Finalize the aggregated information for a job, generating a report fragment."""
         if self.sample_count == 0:
-            return JobResourceMetrics()
+            return JobComputeMetrics()
 
-        return JobResourceMetrics(
+        return JobComputeMetrics(
             max_rss_bytes=self.max_rss,
             avg_rss_bytes=self.sum_rss / self.sample_count,
             avg_cpu_percent=self.sum_cpu / self.sample_count,
-            num_resource_samples=self.sample_count,
+            num_samples=self.sample_count,
         )
 
 
-class ResourceInstrumentation(SchedulerInstrumentation):
-    """Resource instrumentation for the scheduler.
+class ComputeInstrumentation(SchedulerInstrumentation):
+    """Compute resource instrumentation for the scheduler.
 
     Collects information about the compute resources used throughout the entire duration of
     the scheduler, as well as during the window within which each job is dispatched. This
@@ -69,10 +69,10 @@ class ResourceInstrumentation(SchedulerInstrumentation):
     of the samples that fall within that job's execution window.
     """
 
-    name = "resources"
+    name = "compute"
 
     def __init__(self, sample_interval: float = 0.5) -> None:
-        """Construct a resource instrumentation.
+        """Construct a compute resource instrumentation.
 
         Arguments:
             sample_interval: The period (in seconds) per poll / sample produced.
@@ -183,13 +183,13 @@ class ResourceInstrumentation(SchedulerInstrumentation):
                 aggregates = self._running_jobs.pop(job.id)
                 self._finished_jobs[job.id] = aggregates
 
-    def get_scheduler_data(self) -> SchedulerResourceMetrics:
+    def get_scheduler_data(self) -> SchedulerComputeMetrics:
         """Retrieve scheduler metrics measured by this instrumentation."""
         if self._running:
             raise RuntimeError("Cannot build instrumentation report whilst still running!")
 
         if self._sample_count <= 0:
-            return SchedulerResourceMetrics()
+            return SchedulerComputeMetrics()
 
         scheduler_cpu_time = self._scheduler_cpu_time_end - self._scheduler_cpu_time_start
         if self._num_cores is not None:
@@ -202,7 +202,7 @@ class ResourceInstrumentation(SchedulerInstrumentation):
             # Suppress unknown types in VMS measurements
             vms_bytes = None
 
-        return SchedulerResourceMetrics(
+        return SchedulerComputeMetrics(
             scheduler_avg_rss_bytes=round(self._scheduler_sum_rss / self._sample_count),
             scheduler_max_rss_bytes=self._scheduler_max_rss,
             scheduler_vms_bytes=vms_bytes,
@@ -213,10 +213,10 @@ class ResourceInstrumentation(SchedulerInstrumentation):
             sys_cpu_percent=self._sys_sum_cpu / self._sample_count,
             sys_cpu_per_core=sys_cpu_per_core,
             sys_swap_used_bytes=self._sys_max_swap,
-            num_resource_samples=self._sample_count,
+            num_samples=self._sample_count,
         )
 
-    def get_job_data(self) -> Mapping[str, JobResourceMetrics]:
+    def get_job_data(self) -> Mapping[str, JobComputeMetrics]:
         """Retrieve per-job metrics measured by this instrumentation."""
         if self._running:
             raise RuntimeError("Cannot build instrumentation report whilst still running!")

--- a/src/dvsim/instrumentation/factory.py
+++ b/src/dvsim/instrumentation/factory.py
@@ -10,8 +10,8 @@ from dvsim.instrumentation.base import (
     InstrumentationAggregator,
     SchedulerInstrumentation,
 )
+from dvsim.instrumentation.compute import ComputeInstrumentation
 from dvsim.instrumentation.metadata import MetadataInstrumentation
-from dvsim.instrumentation.resources import ResourceInstrumentation
 from dvsim.instrumentation.timing import TimingInstrumentation
 
 __all__ = ("InstrumentationFactory",)
@@ -49,4 +49,4 @@ class InstrumentationFactory:
 # Register implemented instrumentation mechanisms
 InstrumentationFactory.register(MetadataInstrumentation)
 InstrumentationFactory.register(TimingInstrumentation)
-InstrumentationFactory.register(ResourceInstrumentation)
+InstrumentationFactory.register(ComputeInstrumentation)

--- a/src/dvsim/instrumentation/factory.py
+++ b/src/dvsim/instrumentation/factory.py
@@ -43,11 +43,10 @@ class InstrumentationFactory:
         if not names:
             raise ValueError("No instrumentation types given")
 
-        instances: list[SchedulerInstrumentation] = [MetadataInstrumentation()]
-        instances.extend([cls._registry[name]() for name in names])
-        return InstrumentationAggregator(instances)
+        return InstrumentationAggregator([cls._registry[name]() for name in names])
 
 
 # Register implemented instrumentation mechanisms
+InstrumentationFactory.register(MetadataInstrumentation)
 InstrumentationFactory.register(TimingInstrumentation)
 InstrumentationFactory.register(ResourceInstrumentation)

--- a/src/dvsim/instrumentation/factory.py
+++ b/src/dvsim/instrumentation/factory.py
@@ -23,9 +23,9 @@ class InstrumentationFactory:
     _registry: ClassVar[dict[str, type[SchedulerInstrumentation]]] = {}
 
     @classmethod
-    def register(cls, name: str, constructor: type[SchedulerInstrumentation]) -> None:
+    def register(cls, inst_cls: type[SchedulerInstrumentation]) -> None:
         """Register a new scheduler instrumentation type."""
-        cls._registry[name] = constructor
+        cls._registry[inst_cls.name] = inst_cls
 
     @classmethod
     def options(cls) -> list[str]:
@@ -49,5 +49,5 @@ class InstrumentationFactory:
 
 
 # Register implemented instrumentation mechanisms
-InstrumentationFactory.register("timing", TimingInstrumentation)
-InstrumentationFactory.register("resources", ResourceInstrumentation)
+InstrumentationFactory.register(TimingInstrumentation)
+InstrumentationFactory.register(ResourceInstrumentation)

--- a/src/dvsim/instrumentation/records.py
+++ b/src/dvsim/instrumentation/records.py
@@ -17,14 +17,14 @@ from pydantic import (
 __all__ = (
     "InstrumentationMetrics",
     "InstrumentationResults",
+    "JobComputeMetrics",
     "JobInstrumentationMetadata",
     "JobInstrumentationResults",
     "JobMetrics",
-    "JobResourceMetrics",
     "JobTimingMetrics",
+    "SchedulerComputeMetrics",
     "SchedulerInstrumentationResults",
     "SchedulerMetrics",
-    "SchedulerResourceMetrics",
     "SchedulerTimingMetrics",
 )
 
@@ -112,11 +112,11 @@ class JobTimingMetrics(JobMetrics):
         return data
 
 
-# Resource Metrics
+# Compute Resource Metrics
 
 
-class SchedulerResourceMetrics(SchedulerMetrics):
-    """Instrumented resource metrics measured for the scheduler as a whole."""
+class SchedulerComputeMetrics(SchedulerMetrics):
+    """Instrumented compute resource metrics measured for the scheduler as a whole."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -134,11 +134,11 @@ class SchedulerResourceMetrics(SchedulerMetrics):
     sys_cpu_percent: float | None = None
     sys_cpu_per_core: list[float] | None = None
 
-    num_resource_samples: int = 0
+    num_samples: int = 0
 
 
-class JobResourceMetrics(JobMetrics):
-    """Instrumented resource metrics measured for a single scheduled job."""
+class JobComputeMetrics(JobMetrics):
+    """Instrumented compute resource metrics measured for a single scheduled job."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -146,7 +146,7 @@ class JobResourceMetrics(JobMetrics):
     avg_rss_bytes: float | None = None
     avg_cpu_percent: float | None = None
 
-    num_resource_samples: int = 0
+    num_samples: int = 0
 
 
 # Combined output reports
@@ -158,7 +158,7 @@ class SchedulerInstrumentationResults(BaseModel):
     model_config = ConfigDict(frozen=True, extra="allow")
 
     timing: SchedulerTimingMetrics | None = None
-    resources: SchedulerResourceMetrics | None = None
+    compute: SchedulerComputeMetrics | None = None
 
 
 class JobInstrumentationResults(BaseModel):
@@ -168,7 +168,7 @@ class JobInstrumentationResults(BaseModel):
 
     meta: JobInstrumentationMetadata | None = None
     timing: JobTimingMetrics | None = None
-    resources: JobResourceMetrics | None = None
+    compute: JobComputeMetrics | None = None
 
 
 class InstrumentationResults(BaseModel):


### PR DESCRIPTION
This PR is the fourth of a series of PRs to introduce instrumentation reporting to DVSim, which in this case also involves refactoring the existing instrumentation implementation to allow better modeling & static typing around this use case.

This PR performs some final small cleanups after the instrumentation refactoring work in the preceding PRs. Alongside removing some duplication of the instrumentation names, it primarily focuses on improving the user experience:
1. Make metadata an explicit instrumentation type, to replace the unintuitive behaviour where it is automatically added alongside other instrumentation types.
2. Rename the `resources` instrumentation to `compute`, to make it clear that we are measuring "compute resources" and not the new "resources" concept that was introduced to the scheduler in #184 for more granular parallelism limits.
3. Add a special `all` instrumentation type which automatically includes all the available instrumentations. This lets you type `--instrument all` instead of `--instrument meta timing compute`, which can get overly verbose.

See the commit messages for more info.