### PR TITLE
Add block information to the instrumentation job metadata

### DIFF
--- a/src/dvsim/instrumentation/metadata.py
+++ b/src/dvsim/instrumentation/metadata.py
@@ -41,6 +41,8 @@ class MetadataInstrumentation(SchedulerInstrumentation):
                 job_type=spec.job_type,
                 target=spec.target,
                 tool=spec.tool.name,
+                block=spec.block.name,
+                block_variant=spec.block.variant,
                 backend=spec.backend,
                 dependencies=list(spec.dependencies),
                 status=status_str,

--- a/src/dvsim/instrumentation/records.py
+++ b/src/dvsim/instrumentation/records.py
@@ -52,6 +52,8 @@ class JobInstrumentationMetadata(JobMetrics):
     job_type: str
     target: str
     tool: str
+    block: str
+    block_variant: str | None
     backend: str | None
     dependencies: list[str]
     status: str


### PR DESCRIPTION
This PR is the fifth of a series of PRs to introduce instrumentation reporting to DVSim.

A very simple addition - also capture the block & block variant alongside the existing metadata during instrumentation. Although this could technically be inferred from the full name of the job, having these fields explicitly available through a clear interface is much cleaner.

This will allow us to make visualizations / calculate metrics based on run results partitioned by block or block variant.