### PR TITLE
doc: Release / contribution guide updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,58 @@
+<!--
+CONTRIBUTION GUIDELINES
+=======================
+
+For a full reference, refer to the following documents:
+- CONTRIBUTING.md
+- CLA
+
+COMMIT FORMAT
+=============
+Each commit merged from this PR drives an automatic release. Choose the right
+type — it directly determines the version bump on the next release.
+
+  TYPE        SEMVER IMPACT    USE WHEN...
+  ─────────────────────────────────────────────────────────────────────────────
+  feat        minor bump       adding new user-facing behaviour or CLI options
+  fix         patch bump       correcting a bug in existing behaviour
+  perf        patch bump       improving performance without changing behaviour
+  refactor    patch bump       restructuring code without changing behaviour
+  docs        no release       documentation-only changes
+  test        no release       adding or fixing tests
+  ci          no release       CI workflow changes
+  chore       no release       maintenance (deps, tooling, config)
+  build       no release       build system changes
+  revert      patch bump       reverting a previous commit
+
+BREAKING CHANGES → major bump
+  Append ! to the type:  feat!: remove --legacy-flag
+  Or add a footer:       BREAKING CHANGE: <description>
+
+FORMAT
+  <type>[(<scope>)][!]: <short description>   ← 100 chars max
+  <blank line>
+  <optional body>
+  <blank line>
+  Signed-off-by: Name <email>                 ← required; use git commit -s
+
+EXAMPLES
+  feat(scheduler): add --max-jobs CLI flag
+  fix: handle empty testplan gracefully
+  feat!: remove Python 3.9 support
+  refactor(sim): extract tool selection into factory
+
+For further info about the release processes, refer to the the following documents:
+- doc/releasing.md
+-->
+
+## Description
+
+<!-- Describe what this PR does and why. -->
+
+## Checklist
+
+- [ ] All commits are signed off (`git commit -s`), indicating acceptance of the CLA
+- [ ] Commit messages follow the conventional commit format (`<type>[(<scope>)][!]: <description>`)
+  - [ ] The commit type correctly reflects the semver impact of the change
+  - [ ] Breaking changes are marked with `!` or a `BREAKING CHANGE:` footer
+- [ ] New behaviour is covered by tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,54 +3,56 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 -->
-# Contributing code to the opentitan repository
+# Contributing to DVSim
 
 ## Contributor License Agreement
 
-Contributions to OpenTitan must be accompanied by sign-off text that indicates
-acceptance of the Contributor License Agreement (see [CLA](CLA) for full
-text), which is closely derived from the Apache Individual Contributor License
-Agreement. The sign-off text must be included once per commit, in the commit
-message. The sign-off can be automatically inserted using a command such as
-`git commit -s`, which will generate the text in the form:
-`Signed-off-by: Random J Developer <random@developer.example.org>`
+Contributions must be accompanied by a sign-off indicating acceptance of the
+Contributor License Agreement (see [CLA](CLA) for full text). The sign-off is
+added once per commit in the commit message footer, and can be inserted
+automatically with:
 
-By adding this sign-off, you are certifying:
+```
+git commit -s
+```
 
-_By signing-off on this submission, I agree to be bound by the terms of the
-Contributor License Agreement located at the root of the project repository,
-and I agree that this submission constitutes a "Contribution" under that
-Agreement._
+This produces a line of the form:
 
-Please note that this project and any contributions to it are public and that
-a record of all contributions (including any personal information submitted
-with it, including a sign-off) is maintained indefinitely and may be
-redistributed consistent with this project or the open source license(s)
-involved.
+```
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
 
-## Quick guidelines
+By adding this sign-off you are certifying:
 
-* Keep a clean commit history. This means no merge commits, and no long series
-  of "fixup" patches (rebase or squash as appropriate). Structure work as a
-  series of logically ordered, atomic patches. `git rebase -i` is your friend.
-* Changes should be made via pull request, with review. A pull request will be
-  committed by a "committer" (an account listed in `COMMITTERS`) once it has
-  had an explicit positive review.
-* When changes are restricted to a specific area, you are recommended to add a
-  tag to the beginning of the first line of the commit message in square
-  brackets. e.g. "[uart] Fix bug #157".
-* Code review is not design review and doesn't remove the need for discussing
-  implementation options. If you would like to make a large-scale change or
-  discuss multiple implementation options, discuss on the mailing list.
-* Create pull requests from a fork rather than making new branches in
-  `github.com/lowrisc/opentitan`.
-* Do not attempt to commit code with a non-Apache license without discussing
-  first.
-* If a relevant bug or tracking issue exists, reference it in the pull request
-  and commits.
-* Do not report security vulnerabilities through public GitHub issues or pull
-  requests. For instructions on how to report vulnerabilities, please consult
-  SECURITY.md.
+_I agree to be bound by the terms of the Contributor License Agreement located
+at the root of the project repository, and I agree that this submission
+constitutes a "Contribution" under that Agreement._
 
-Please see [Contributing to OpenTitan](https://opentitan.org/book/doc/contributing)
-for more general guidance.
+Note that this project and any contributions to it are public. A record of all
+contributions (including any personal information submitted with it) is
+maintained indefinitely and may be redistributed consistent with this project
+or the open source license(s) involved.
+
+## Commit messages
+
+DVSim uses [Conventional Commits](https://www.conventionalcommits.org/) to
+drive automatic semantic versioning. Every commit that lands on `master` is
+parsed by `python-semantic-release` and the commit type determines the version
+bump in the next release. **Choosing the right type is important.**
+
+The summary line must be 100 characters or fewer.
+See [docs/releasing.md](doc/releasing.md) for the full type list and their semver
+impact.
+
+## Pull requests
+
+- Changes must go through a pull request with at least one review before merge.
+- Keep a clean commit history: no merge commits, no long chains of fixup patches.
+  Use `git rebase -i` to squash or reorder before requesting review.
+- Create pull requests from a fork rather than from branches in the upstream
+  repository.
+- If a relevant bug or tracking issue exists, reference it in the PR description
+  and in the commit message body.
+- Do not report security vulnerabilities through public GitHub issues or pull
+  requests. See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
+- Do not include code under a non-Apache license without prior discussion.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -1,0 +1,95 @@
+<!--
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+-->
+
+# Releasing DVSim
+
+DVSim uses [python-semantic-release](https://python-semantic-release.readthedocs.io/)
+to automate versioning and releases. Releases are created automatically when commits
+land on `master` — there is no manual step to cut a release.
+
+## How it works
+
+1. A pull request is merged to `master`.
+2. The `release` CI workflow runs `semantic-release version`, which inspects all
+   commits since the previous release tag.
+3. The highest-impact commit type in the changeset determines the version bump.
+4. If any release-triggering commits are present, semantic-release:
+   - Bumps the version in `pyproject.toml` and re-locks `uv.lock`
+   - Updates `CHANGELOG.md`
+   - Creates a signed release commit and a `vX.Y.Z` tag
+   - Pushes the commit and tag to `master`
+   - Creates a GitHub Release with source and distribution artifacts
+   - Publishes the distribution to PyPI and TestPyPI
+
+If no commit since the last release has a release-triggering type, no release is
+created and the workflow exits cleanly.
+
+## Commit types and semver impact
+
+The commit type in each conventional commit message determines the version bump.
+The highest-impact type across all commits since the last release wins.
+
+| Type | Semver impact | Version example |
+|---|---|---|
+| Any type with `!` or `BREAKING CHANGE:` footer | **major** | `1.2.3` → `2.0.0` |
+| `feat` | **minor** | `1.2.3` → `1.3.0` |
+| `fix` | patch | `1.2.3` → `1.2.4` |
+| `perf` | patch | `1.2.3` → `1.2.4` |
+| `refactor` | patch | `1.2.3` → `1.2.4` |
+| `docs` | none — no release | — |
+| `test` | none — no release | — |
+| `ci` | none — no release | — |
+| `chore` | none — no release | — |
+| `build` | none — no release | — |
+| `style` | none — no release | — |
+| `revert` | patch | `1.2.3` → `1.2.4` |
+
+### Breaking changes
+
+A **major** bump is triggered by either:
+
+- Appending `!` to the type: `feat!: remove --legacy-flag`
+- Adding a `BREAKING CHANGE:` footer to the commit body:
+
+  ```
+  feat: overhaul job configuration format
+
+  BREAKING CHANGE: The `resources:` key in job HJSON configs is replaced
+  by `compute:`. Existing configs must be updated.
+  ```
+
+### Squash commits
+
+If a PR is squash-merged, the resulting single commit must itself carry a
+valid conventional commit type. `parse_squash_commits = true` is set in
+`pyproject.toml`, so semantic-release will also scan the squash commit body
+for conventional commit lines from the original commits.
+
+## Viewing the changelog
+
+The [CHANGELOG.md](../CHANGELOG.md) at the repository root is updated
+automatically by semantic-release on each release. It groups changes by type
+and links to the commits and the GitHub diff for each release.
+
+## Configuration
+
+Semantic-release is configured in `pyproject.toml` under
+`[tool.semantic_release]`. Key settings:
+
+```toml
+[tool.semantic_release]
+commit_parser = "conventional"
+version_toml = ["pyproject.toml:project.version"]
+
+[tool.semantic_release.commit_parser_options]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf", "refactor"]
+parse_squash_commits = true
+ignore_merge_commits = true
+```
+
+The release workflow definition is in
+[`.github/workflows/release.yml`](../.github/workflows/release.yml).

--- a/scripts/license_check.py
+++ b/scripts/license_check.py
@@ -24,6 +24,7 @@ IGNORE_NAMES = [
     "NOTICE",
     ".python-version",
     "CHANGELOG.md",
+    "pull_request_template.md",
 ]
 
 IGNORE_SUFFIXES = [


### PR DESCRIPTION
Flesh out the contribution guidelines and docs to better reflect the use of conventional commits / semantic-release to automate project releases, and the expectations upon contributors to follow these guidelines to categorize their contributions appropriately.

- Add a `releasing.md` document explaining the conventional commits style and automated release processes.
- Updating the CONTRIBUTING.md file to also describe the requirement for following the commit style guides for automated release management. Also strip out a bit of opentitan-specific guidance that no longer applies within this project.
- Add a pull request template message, which summarizes the commit message guidelines, and points the user towards the releasing documentation for a fuller reference. Finish off with a checklist for the contributor to confirm that they have met these requirements with their changes.