### PR TITLE
fix: Raise a helpful error on a bogus testplan

### DIFF
--- a/src/dvsim/testplan.py
+++ b/src/dvsim/testplan.py
@@ -255,24 +255,31 @@ class Testplan:
         sys.exit(1)
 
     @staticmethod
-    def _create_testplan_elements(kind: str, raw_dicts_list: list, tags: set):
-        """Creates testplan elements from the list of raw dicts.
+    def _create_testplan_elements(kind: str, raw_dicts_list: list, tags: set) -> list[Element]:
+        """Create testplan elements from the list of raw dicts.
 
         kind is either 'testpoint' or 'covergroup'.
         raw_dicts_list is a list of dictionaries extracted from the HJson file.
         """
         items = []
         item_names = set()
+
+        try:
+            elem_cls = Testplan.element_cls[kind]
+        except KeyError:
+            err_msg = f"No known class for kind={kind}"
+            raise RuntimeError(err_msg) from None
+
         for dict_entry in raw_dicts_list:
             try:
-                item = Testplan.element_cls[kind](dict_entry)
-            except KeyError:
-                sys.exit(1)
-            except ValueError:
-                sys.exit(1)
+                item = elem_cls(dict_entry)
+            except (KeyError, ValueError) as e:
+                err_msg = f"Failed to create {kind} from dictionary."
+                raise RuntimeError(err_msg) from e
 
             if item.name in item_names:
-                sys.exit(1)
+                err_msg = f"Duplicate items with name {item.name}."
+                raise ValueError(err_msg)
 
             # Filter out the item by tags if provided.
             if item.has_tags(tags):


### PR DESCRIPTION
I found this because I had added a problem to a testplan and running dvsim on the resulting block didn't work. But it failed silently!

Now, you get a backtrace:
```
  ...
    File "/home/rjs/work/dvsim/src/dvsim/sim/flow.py", line 324, in _create_objects
      self.testplan = Testplan(
                      ^^^^^^^^^
    File "/home/rjs/work/dvsim/src/dvsim/testplan.py", line 350, in __init__
      self._parse_testplan(filename, tags, repo_top)
    File "/home/rjs/work/dvsim/src/dvsim/testplan.py", line 463, in _parse_testplan
      self.covergroups = self._create_testplan_elements("covergroup", covergroups, set())
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/rjs/work/dvsim/src/dvsim/testplan.py", line 284, in _create_testplan_elements
      raise ValueError(err_msg)
  ValueError: Duplicate items with name handshake_complete_cg.

(which also tells me what I did wrong in my OpenTitan patch!)
```
