### PR TITLE
Improve instrumentation job metadata modelling

### DIFF
--- a/src/dvsim/instrumentation/metadata.py
+++ b/src/dvsim/instrumentation/metadata.py
@@ -26,12 +26,11 @@ class MetadataInstrumentation(SchedulerInstrumentation):
     def __init__(self) -> None:
         """Construct a `MetadataInstrumentation`."""
         super().__init__()
-        self._jobs: dict[str, tuple[JobSpec, str]] = {}
+        self._jobs: dict[str, tuple[JobSpec, JobStatus]] = {}
 
     def on_job_status_change(self, job: JobSpec, status: JobStatus) -> None:
         """Notify instrumentation of a change in status for some scheduled job."""
-        status_str = status.name.capitalize()
-        self._jobs[job.id] = (job, status_str)
+        self._jobs[job.id] = (job, status)
 
     def get_job_data(self) -> Mapping[str, JobInstrumentationMetadata]:
         """Retrieve per-job metrics measured by this instrumentation."""
@@ -45,7 +44,7 @@ class MetadataInstrumentation(SchedulerInstrumentation):
                 block_variant=spec.block.variant,
                 backend=spec.backend,
                 dependencies=list(spec.dependencies),
-                status=status_str,
+                status=status,
             )
-            for spec, status_str in self._jobs.values()
+            for spec, status in self._jobs.values()
         }

--- a/src/dvsim/instrumentation/records.py
+++ b/src/dvsim/instrumentation/records.py
@@ -53,8 +53,8 @@ class JobInstrumentationMetadata(JobMetrics):
     target: str
     tool: str
     block: str
-    block_variant: str | None
-    backend: str | None
+    block_variant: str | None = None
+    backend: str | None = None
     dependencies: list[str]
     status: str
 

--- a/src/dvsim/instrumentation/records.py
+++ b/src/dvsim/instrumentation/records.py
@@ -14,6 +14,8 @@ from pydantic import (
     model_validator,
 )
 
+from dvsim.job.status import JobStatus
+
 __all__ = (
     "InstrumentationMetrics",
     "InstrumentationResults",
@@ -56,7 +58,7 @@ class JobInstrumentationMetadata(JobMetrics):
     block_variant: str | None = None
     backend: str | None = None
     dependencies: list[str]
-    status: str
+    status: JobStatus
 
 
 # Timing metrics

--- a/src/dvsim/job/status.py
+++ b/src/dvsim/job/status.py
@@ -4,7 +4,7 @@
 
 """An enum definition for the various job statuses."""
 
-from enum import Enum, auto
+from enum import Enum
 
 __all__ = ("JobStatus",)
 
@@ -12,12 +12,12 @@ __all__ = ("JobStatus",)
 class JobStatus(Enum):
     """Status of a Job."""
 
-    SCHEDULED = auto()  # Waiting for dependencies
-    QUEUED = auto()  # Dependencies satisfied, waiting to be dispatched
-    RUNNING = auto()  # Dispatched to a backend and actively executing
-    PASSED = auto()  # Completed successfully
-    FAILED = auto()  # Completed with failure
-    KILLED = auto()  # Forcibly terminated or never executed
+    SCHEDULED = "Scheduled"  # Waiting for dependencies
+    QUEUED = "Queued"  # Dependencies satisfied, waiting to be dispatched
+    RUNNING = "Running"  # Dispatched to a backend and actively executing
+    PASSED = "Passed"  # Completed successfully
+    FAILED = "Failed"  # Completed with failure
+    KILLED = "Killed"  # Forcibly terminated or never executed
 
     @property
     def shorthand(self) -> str:


### PR DESCRIPTION
This PR is the seventh of a series of PRs to introduce instrumentation reporting to DVSim.

This PR does a little bit of cleanup of the instrumentation job metadata record introduced in previous PRs, to make it more useful for the incoming visualization PRs. There is no externally visible change to the instrumentation output - just the internal Pydantic models.

See the commit messages for more information.