### PR TITLE
Introduce instrumentation report utilities

### DIFF
--- a/src/dvsim/instrumentation/records.py
+++ b/src/dvsim/instrumentation/records.py
@@ -17,6 +17,7 @@ from pydantic import (
 from dvsim.job.status import JobStatus
 
 __all__ = (
+    "ConcreteJobTimingMetrics",
     "InstrumentationMetrics",
     "InstrumentationResults",
     "JobComputeMetrics",
@@ -116,6 +117,16 @@ class JobTimingMetrics(JobMetrics):
         return data
 
 
+class ConcreteJobTimingMetrics(JobMetrics):
+    """Concrete job timing information with all known fields populated."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    start_time: float
+    end_time: float
+    duration: float
+
+
 # Compute Resource Metrics
 
 
@@ -182,3 +193,27 @@ class InstrumentationResults(BaseModel):
 
     scheduler: SchedulerInstrumentationResults
     jobs: dict[str, JobInstrumentationResults] = Field(default_factory=dict)
+
+    def job_timings(self) -> dict[str, ConcreteJobTimingMetrics]:
+        """Get any complete job timing information that exists in this instrumentation report."""
+        return {
+            job_id: ConcreteJobTimingMetrics(
+                start_time=results.timing.start_time,
+                end_time=results.timing.end_time,
+                duration=(results.timing.end_time - results.timing.start_time),
+            )
+            for job_id, results in self.jobs.items()
+            if results.timing is not None
+            and results.timing.start_time is not None
+            and results.timing.end_time is not None
+        }
+
+    def get_run_time_info(self) -> tuple[float, float]:
+        """Get the run start & end time, falling back to job info if scheduler info is missing."""
+        timing = self.scheduler.timing
+        if timing is None or timing.start_time is None or timing.end_time is None:
+            job_timings = self.job_timings()
+            start_time = min((time.start_time for time in job_timings.values()), default=0.0)
+            end_time = max((time.end_time for time in job_timings.values()), default=0.0)
+            return start_time, end_time
+        return timing.start_time, timing.end_time

--- a/src/dvsim/instrumentation/report/base.py
+++ b/src/dvsim/instrumentation/report/base.py
@@ -4,24 +4,44 @@
 
 """DVSim scheduler instrumentation reporting & visualizations."""
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from enum import Enum
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol, TypeVar
 
+import plotly.graph_objects as go
 import plotly.offline
 from typing_extensions import Self
 
 from dvsim.instrumentation import InstrumentationResults
+from dvsim.instrumentation.records import JobInstrumentationMetadata
 from dvsim.logging import log
 from dvsim.report.artifacts import ReportArtifacts, render_static_content
 from dvsim.templates.render import render_template
 
 __all__ = (
+    "DEFAULT_VISUALIZATION_HEIGHT_PX",
+    "PLOTLY_TIMING_AXIS_CONFIG",
     "InstrumentationVisualizer",
     "RenderProfile",
+    "make_job_metadata_hover",
+    "make_repeating_color_map",
     "render_html_report",
+    "render_plotly_figure",
 )
+
+# The default figure height limit in pixels that visualizations should target, if possible.
+DEFAULT_VISUALIZATION_HEIGHT_PX: int = 1000
+
+# Standard plotly timing axis/tick config options
+PLOTLY_TIMING_AXIS_CONFIG: dict[str, Any] = {
+    "title": "Time (s)",
+    "tickformat": ",",
+    "ticks": "outside",
+    "tickwidth": 1,
+    "ticklen": 4,
+    "tickcolor": "black",
+}
 
 
 class RenderProfile(Enum):
@@ -130,3 +150,90 @@ def render_html_report(
             (outdir / plotly_js_path).write_text(artifacts[plotly_js_path])
 
     return artifacts
+
+
+def render_plotly_figure(fig: go.Figure, *args: list[Any], **kwargs: dict[str, Any]) -> str:
+    """Render a plotly figure / visualization to a HTML fragment to insert into a report.
+
+    Args:
+        fig: The plotly figure to render.
+        args: Any extra arguments to pass to `fig.to_html(...)`.
+        kwargs: Any extra keyword arguments to pass to `fig.to_html(...)`.
+
+    Returns:
+        The HTML fragment corresponding to the plotly Figure, without plotly.js included.
+
+    """
+    return fig.to_html(*args, full_html=False, include_plotlyjs=False, **kwargs)
+
+
+def make_job_metadata_hover(
+    job_id: str,
+    extra: Iterable[str] | Mapping[str, str] | None,
+    metadata: JobInstrumentationMetadata | None,
+    *,
+    omit_status: bool = False,
+) -> str:
+    """Make tooltip hover text for a graph item corresponding to some DVSim job.
+
+    Args:
+        job_id: The ID / full name of the job (displayed as the title).
+        extra: Any extra lines or key/value mapping to insert after the title & before metadata.
+        metadata: Any optional metadata to include at the end of the tooltip.
+        omit_status: A flag to disable display of status metadata. Useful for combined job views,
+          where jobs may have inconsistent statuses (e.g. flaky results).
+
+    Returns:
+        The tooltip hover HTML text for the job, intended to be used with plotly's `hovertemplate`.
+
+    """
+    lines = [f"<b>{job_id}</b>"]
+
+    if extra is not None:
+        if isinstance(extra, Mapping):
+            for key, value in extra.items():
+                lines.append(f"{key}: {value}")
+        else:
+            lines += list(extra)
+
+    if metadata is not None:
+        block_info = metadata.block
+        if metadata.block_variant:
+            block_info += f" ({metadata.block_variant})"
+        lines += [
+            "------------------",
+            f"Name: {metadata.name}",
+            f"Tool: {metadata.tool}",
+            f"Block: {block_info}",
+            f"Target: {metadata.target}",
+        ]
+        if not omit_status:
+            lines.append(f"Status: {metadata.status.value}")
+        if metadata.backend is not None:
+            lines.append(f"Backend: {metadata.backend}")
+
+    return "<br>".join(lines)
+
+
+T = TypeVar("T")
+
+
+def make_repeating_color_map(data: Iterable[str], colors: Iterable[T]) -> dict[str, T]:
+    """Make a color mapping that repeats for as long as is needed to fit the amount of data.
+
+    Args:
+        data: The category strings to map to the colors.
+        colors: The non-empty color items to be mapped. Repeated if needed to match `data`.
+
+    Returns:
+        The mapping from data items -> color, in a cyclically repeating order.
+
+    """
+    data = list(data)
+    colors = list(colors)
+    if len(colors) == 0:
+        raise ValueError("Given an empty list of colors to repeat?")
+
+    while len(colors) < len(data):
+        colors += colors.copy()
+    return dict(zip(data, colors, strict=False))

--- a/src/dvsim/utils/__init__.py
+++ b/src/dvsim/utils/__init__.py
@@ -8,7 +8,13 @@ from dvsim.utils.check import check_bool, check_int
 from dvsim.utils.fs import clean_odirs, mk_path, mk_symlink, rm_path
 from dvsim.utils.hjson import parse_hjson
 from dvsim.utils.subprocess import run_cmd, run_cmd_with_timeout
-from dvsim.utils.time import TS_FORMAT, TS_FORMAT_LONG, TS_HMS_FORMAT
+from dvsim.utils.time import (
+    TS_FORMAT,
+    TS_FORMAT_LONG,
+    TS_HMS_FORMAT,
+    format_time_as_hms,
+    format_time_metric,
+)
 from dvsim.utils.wildcards import (
     find_and_substitute_wildcards,
     subst_wildcards,
@@ -22,6 +28,8 @@ __all__ = (
     "check_int",
     "clean_odirs",
     "find_and_substitute_wildcards",
+    "format_time_as_hms",
+    "format_time_metric",
     "mk_path",
     "mk_symlink",
     "parse_hjson",

--- a/src/dvsim/utils/time.py
+++ b/src/dvsim/utils/time.py
@@ -12,3 +12,48 @@ TS_FORMAT_LONG = "%A %B %d %Y %H:%M:%S UTC"
 
 # Timestamp format for Hours:Minutes:Seconds display as used by the scheduler
 TS_HMS_FORMAT = "%H:%M:%S"
+
+
+def format_time_as_hms(seconds: float, *, decimals: int = 2, omit_zero: bool = False) -> str:
+    """Format a time in seconds like '12h 34m 56.79s'.
+
+    Args:
+        seconds: The time in seconds to format.
+        decimals: The number of decimal places to use for non-integer seconds (default 2).
+        omit_zero: True if zero fields (e.g. '0h 0m') should be omitted, false otherwise.
+
+    Returns:
+        A formatted time string.
+
+    """
+    if seconds < 0:
+        msg = f"Cannot format negative time value: {seconds}s"
+        raise ValueError(msg)
+
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    hms = f"{secs:.{decimals}f}s"
+    if minutes > 0 or hours > 0 or not omit_zero:
+        hms = f"{int(minutes)}m " + hms
+    if hours > 0 or not omit_zero:
+        hms = f"{int(hours)}h " + hms
+    return hms
+
+
+def format_time_metric(
+    seconds: float, *, hms_decimals: int = 2, second_decimals: int = 2, omit_zero: bool = False
+) -> str:
+    """Return a time metric formatted as e.g. '2h 15m 37.21s (8,137.21s)'.
+
+    Args:
+        seconds: The time in seconds to format.
+        hms_decimals: The number of decimal places to use for the 'Xh Ym Zs' output.
+        second_decimals: The number of decimal places to use for the '(Xs)' output.
+        omit_zero: True if zero fields (e.g. '0h 0m') should be omitted, false otherwise.
+
+    Returns:
+        A formatted string for the given time metric value.
+
+    """
+    hms = format_time_as_hms(seconds, decimals=hms_decimals, omit_zero=omit_zero)
+    return f"{hms} ({seconds:,.{second_decimals}f}s)"

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -1,0 +1,74 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test time-based utilities."""
+
+import pytest
+from hamcrest import assert_that, calling, equal_to, raises
+
+from dvsim.utils.time import format_time_as_hms, format_time_metric
+
+
+@pytest.mark.parametrize("seconds", [-0.001, -1, -500, -999999])
+@pytest.mark.parametrize("decimals", [0, 2, 10])
+def test_format_negative_times(seconds: float, decimals: int) -> None:
+    """Test that the time formatting functions do not allow negative times to be provided."""
+    assert_that(
+        calling(format_time_as_hms).with_args(seconds, decimals=decimals),
+        raises(ValueError, "negative"),
+    )
+    assert_that(
+        calling(format_time_metric).with_args(
+            seconds, hms_decimals=decimals, second_decimals=decimals
+        ),
+        raises(ValueError, "negative"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("seconds", "decimals", "omit_zero", "expected"),
+    [
+        (0, 0, True, "0s"),
+        (0, 0, False, "0h 0m 0s"),
+        (1.2345, 0, True, "1s"),
+        (1.2345, 2, True, "1.23s"),
+        (1.2345, 5, True, "1.23450s"),
+        (9.8765, 2, True, "9.88s"),
+        (1.2345, 2, False, "0h 0m 1.23s"),
+        (60, 0, False, "0h 1m 0s"),
+        (98.765, 1, True, "1m 38.8s"),
+        (3600, 0, True, "1h 0m 0s"),
+        (1234567.89, 2, True, "342h 56m 7.89s"),
+    ],
+)
+def test_format_time(*, seconds: float, decimals: int, omit_zero: bool, expected: str) -> None:
+    """Test that times can be correctly formatted in hour/minute/second format."""
+    assert_that(
+        format_time_as_hms(seconds, decimals=decimals, omit_zero=omit_zero), equal_to(expected)
+    )
+
+
+@pytest.mark.parametrize(
+    ("seconds", "hms_decimals", "second_decimals", "omit_zero", "expected"),
+    [
+        (0, 0, 0, True, "0s (0s)"),
+        (0, 0, 0, False, "0h 0m 0s (0s)"),
+        (1.2345, 0, 0, True, "1s (1s)"),
+        (1.2345, 2, 5, False, "0h 0m 1.23s (1.23450s)"),
+        (60, 0, 0, False, "0h 1m 0s (60s)"),
+        (98.765, 1, 5, True, "1m 38.8s (98.76500s)"),
+        (3600, 0, 0, True, "1h 0m 0s (3,600s)"),
+        (1234567.89, 1, 2, True, "342h 56m 7.9s (1,234,567.89s)"),
+    ],
+)
+def test_format_time_metric(
+    *, seconds: float, hms_decimals: int, second_decimals: int, omit_zero: bool, expected: str
+) -> None:
+    """Test that metric times can be correctly formatted."""
+    assert_that(
+        format_time_metric(
+            seconds, hms_decimals=hms_decimals, second_decimals=second_decimals, omit_zero=omit_zero
+        ),
+        equal_to(expected),
+    )


### PR DESCRIPTION
This PR is the eighth of a series of PRs to introduce instrumentation reporting to DVSim.

This PR adds some helper utilities that will be used throughout the various instrumentation visualizations. These are not used yet in this PR - in an effort to split the changes up into multiple PRs and make them easier to review. There are a variety of helpers across the commits - some for time string formatting, some for retrieving concrete timing information from the report data, and some for rendering Plotly figures and deriving consistent colour mappings across visualizations.

(note on the time string formatting specifically: `datetime` does let you get some format like "Xh Ym Zs", but it doesn't let you omit leading zero values which is nice for presentation in the reports. We could hack on top and strip leading string prefixes but it's simple enough to just re-implement that I decided to do that here. We also could pull in some third-party deps, but that seems unnecessary for just this functionality).

See the commit messages for more information.