### PR TITLE
Add parallelism timeline graph to the HTML instrumentation report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "tabulate>=0.9.0",
     "toml>=0.10.2",
-    # Needed for Self while supporting Python 3.10
+    # Needed for Self while supporting Python 3.10 & override for 3.10 & 3.11
     "typing-extensions>=4.15.0",
 ]
 

--- a/src/dvsim/instrumentation/report/registry.py
+++ b/src/dvsim/instrumentation/report/registry.py
@@ -7,7 +7,7 @@
 from typing import ClassVar
 
 from dvsim.instrumentation.report.base import InstrumentationVisualizer, RenderProfile
-from dvsim.instrumentation.report.timelines import TimelineBarChart
+from dvsim.instrumentation.report.timelines import ParallelismChart, TimelineBarChart
 
 __all__ = ("ReportVisualizationRegistry",)
 
@@ -50,3 +50,4 @@ class ReportVisualizationRegistry:
 
 # Register implemented / built-in instrumentation report visualizations
 ReportVisualizationRegistry.register(TimelineBarChart)
+ReportVisualizationRegistry.register(ParallelismChart)

--- a/src/dvsim/instrumentation/report/timelines.py
+++ b/src/dvsim/instrumentation/report/timelines.py
@@ -5,9 +5,11 @@
 """DVSim scheduler instrumentation timeline (bar chart) visualizations."""
 
 import base64
+import heapq
 from collections import defaultdict
 from dataclasses import dataclass
 from io import BytesIO
+from typing import Any
 
 import matplotlib as mpl
 
@@ -18,10 +20,13 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import plotly.colors as pc
 import plotly.graph_objects as go
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure as MplFigure
 from matplotlib.ticker import MaxNLocator
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from dvsim.instrumentation import InstrumentationResults
+from dvsim.instrumentation.records import ConcreteJobTimingMetrics
 from dvsim.instrumentation.report.base import (
     DEFAULT_VISUALIZATION_HEIGHT_PX,
     PLOTLY_TIMING_AXIS_CONFIG,
@@ -53,6 +58,17 @@ class BarInfo:
     index: int
     tooltip: str
     color: str
+
+
+@dataclass(frozen=True)
+class FigureData:
+    """Information about the rendered timeline bar chart figure."""
+
+    traces: dict[str, list[BarInfo]]
+    indices: dict[str, int]
+    num_indices: int
+    num_jobs: int
+    run_duration: float
 
 
 class TimelineBarChart(InstrumentationVisualizer):
@@ -91,37 +107,59 @@ class TimelineBarChart(InstrumentationVisualizer):
         # Margins to render the bar chart with
         self.margins: dict[str, int] = {"t": 80, "b": 40, "l": 50, "r": 20}
 
-    def _compute_chart_height(self, num_jobs: int) -> int:
+    def _assign_indices(
+        self, jobs_by_start_time: list[tuple[str, ConcreteJobTimingMetrics]]
+    ) -> tuple[dict[str, int], int]:
+        """Assign each job as a bar on the chart to a given index (vertical slot).
+
+        Args:
+            jobs_by_start_time: a list of (job_id, job timing) items pre-ordered by start time.
+
+        Returns:
+            A tuple of (mapping of job_id -> assigned index, num indices).
+
+        """
+        return (
+            {job_id: i for i, (job_id, _) in enumerate(jobs_by_start_time, start=1)},
+            len(jobs_by_start_time),
+        )
+
+    def _compute_chart_height(self, num_indices: int) -> int:
         """Compute the height that should be used for the bar chart figure."""
         vertical_margins = self.margins.get("t", 0) + self.margins.get("b", 0)
-        height = num_jobs * self.max_bar_px + vertical_margins
+        height = num_indices * self.max_bar_px + vertical_margins
         return min(height, DEFAULT_VISUALIZATION_HEIGHT_PX)
 
-    def _compute_bar_thickness(self, num_jobs: int) -> float:
+    def _compute_bar_thickness(self, num_indices: int) -> float:
         """Compute the bar thickness (in visual units, not px) to use for this chart.
 
         Below a configured threshold (`TIMELINE_SCALE_THRESHOLD`) we always render at a minimum
         width. After this knee, we linearly scale to ensure visibility for large amounts.
 
         """
-        if not self.apply_bar_scaling or num_jobs <= TIMELINE_SCALE_THRESHOLD:
+        if not self.apply_bar_scaling or num_indices <= TIMELINE_SCALE_THRESHOLD:
             return 1.0
-        scaled = num_jobs / TIMELINE_SCALE_THRESHOLD * self.min_bar_px
+        scaled = num_indices / TIMELINE_SCALE_THRESHOLD * self.min_bar_px
         return max(1.0, scaled)
 
-    def _get_figure_contents(
-        self, results: InstrumentationResults
-    ) -> dict[str, list[BarInfo]] | None:
+    def _extra_hover_info(
+        self, _job_id: str, _results: InstrumentationResults, _index: int
+    ) -> dict[str, str]:
+        """Get a key->value mapping of extra items to put in the job's tooltip."""
+        return {}
+
+    def _get_figure_contents(self, results: InstrumentationResults) -> FigureData | None:
         """Build the figure contents for some results, mapping categories/traces to bar info."""
         # Get the job & scheduler timing info, and check enough data exists to build a graph.
         job_timings = results.job_timings()
         if not job_timings:
             return None
         jobs_by_start_time = sorted(job_timings.items(), key=lambda kv: kv[1].start_time)
-        run_start_time, _ = results.get_run_time_info()
+        run_start_time, run_end_time = results.get_run_time_info()
+        run_duration = run_end_time - run_start_time
 
         # Determine the index of each bar by start time
-        job_indices = {job_id: i for i, (job_id, _) in enumerate(jobs_by_start_time, start=1)}
+        job_indices, num_indices = self._assign_indices(jobs_by_start_time)
 
         # If any relevant job metadata exists, split bars into subsets keyed by the target.
         categories: dict[str, list[str]] = defaultdict(list)
@@ -149,6 +187,7 @@ class TimelineBarChart(InstrumentationVisualizer):
                     "Start time": format_time_metric(start_time_offset),
                     "End time": format_time_metric(end_time_offset),
                 }
+                extra_timing_info.update(**self._extra_hover_info(job_id, results, index))
                 hover_data = make_job_metadata_hover(job_id, extra_timing_info, metadata)
 
                 figure_info[key].append(
@@ -161,26 +200,62 @@ class TimelineBarChart(InstrumentationVisualizer):
                     )
                 )
 
-        return figure_info
+        num_jobs = sum(len(jobs) for jobs in categories.values())
+        return FigureData(
+            traces=figure_info,
+            indices=job_indices,
+            num_indices=num_indices,
+            num_jobs=num_jobs,
+            run_duration=run_duration,
+        )
 
-    def _render_plotly_figure(
-        self, results: InstrumentationResults, figure_data: dict[str, list[BarInfo]], num_jobs: int
-    ) -> str:
+    def _get_plotly_outline_info(self, num_indices: int) -> dict[str, Any] | None:
+        """Get the bar marker outline information to use for this Plotly figure.
+
+        Below a configured threshold (TIMELINE_SCALE_THRESHOLD), we render as normal. When the
+        number of jobs exceeds this threshold, we make bar outlines less distinctive to avoid
+        small bars overlapping and combining to blot out parts of the graph.
+        """
+        if num_indices <= TIMELINE_SCALE_THRESHOLD:
+            return None
+        return {"width": 0.2, "color": "rgba(0,0,0,0.025)"}
+
+    def _build_plotly_layout(self, fig: go.Figure, figure_data: FigureData) -> None:
+        """Build the layout / presentation options for the Plotly figure."""
+        height = self._compute_chart_height(figure_data.num_indices)
+
+        fig.update_layout(
+            template="plotly_white",
+            title_text=(
+                f"<b>Gantt chart of {figure_data.num_jobs:,} scheduled jobs "
+                f"({format_time(figure_data.run_duration, omit_zero=True)} run length)</b>"
+            ),
+            title_x=0.5,
+            margin=self.margins,
+            height=height,
+        )
+        fig.update_legends(title="Job Target")
+        fig.update_yaxes(title="Job", autorange="reversed")
+        fig.update_xaxes(showgrid=True, **PLOTLY_TIMING_AXIS_CONFIG)
+
+        # Enforce linear integer tick scaling for small numbers of jobs to prevent automatic
+        # interpolation of non-integer ticks.
+        linear_tick_threshold = 10
+        if figure_data.num_indices <= linear_tick_threshold:
+            fig.update_yaxes(tickmode="linear", tick0=1, dtick=1)
+        else:
+            fig.update_yaxes(tickmode="auto", tickformat=",")
+
+    def _render_plotly_figure(self, figure_data: FigureData) -> str:
         """Render a dynamic plotly HTML visualization from the given results & figure data."""
-        # Determine chart dimensions / scaling based on the number of jobs being rendered.
-        run_start_time, run_end_time = results.get_run_time_info()
-        height = self._compute_chart_height(num_jobs)
-        bar_width = self._compute_bar_thickness(num_jobs)
+        # Determine chart scaling based on the number of jobs being rendered.
+        bar_width = self._compute_bar_thickness(figure_data.num_indices)
+        outline = self._get_plotly_outline_info(figure_data.num_indices)
 
         # Render the figure and configure layout & presentation
         fig = go.Figure()
-        outline = (
-            {"width": 0.0}
-            if num_jobs <= TIMELINE_SCALE_THRESHOLD
-            else {"width": 0.2, "color": "rgba(0,0,0,0.025)"}
-        )
 
-        for key, bars in figure_data.items():
+        for key, bars in figure_data.traces.items():
             fig.add_bar(
                 x=[bar.width for bar in bars],
                 y=[bar.index for bar in bars],
@@ -194,41 +269,63 @@ class TimelineBarChart(InstrumentationVisualizer):
                 hovertemplate="%{customdata}<extra></extra>",
             )
 
-        run_duration = run_end_time - run_start_time
-        fig.update_layout(
-            template="plotly_white",
-            title_text=(
-                f"<b>Gantt chart of {num_jobs:,} scheduled jobs "
-                f"({format_time(run_duration, omit_zero=True)} run length)</b>"
-            ),
-            title_x=0.5,
-            margin=self.margins,
-            height=height,
-        )
-        fig.update_legends(title="Job Target")
-        fig.update_yaxes(title="Job", autorange="reversed")
-        fig.update_xaxes(showgrid=True, **PLOTLY_TIMING_AXIS_CONFIG)
-
-        # Enforce linear integer tick scaling for small numbers of jobs to prevent automatic
-        # interpolation of non-integer ticks.
-        linear_tick_threshold = 10
-        if num_jobs <= linear_tick_threshold:
-            fig.update_yaxes(tickmode="linear", tick0=1, dtick=1)
-        else:
-            fig.update_yaxes(tickmode="auto", tickformat=",")
-
+        self._build_plotly_layout(fig, figure_data)
         return render_plotly_figure(fig)
 
-    def _render_matplotlib_figure(
-        self, results: InstrumentationResults, figure_data: dict[str, list[BarInfo]], num_jobs: int
-    ) -> str:
+    def _build_matplotlib_layout(self, fig: MplFigure, axes: Axes, figure_data: FigureData) -> None:
+        """Build the layout / presentation options for the matplotlib figure."""
+        title = (
+            f"Gantt chart of {figure_data.num_jobs:,} scheduled jobs "
+            f"({format_time(figure_data.run_duration, omit_zero=True)} run length)"
+        )
+        axes.set_title(title, fontweight="bold")
+
+        # Render the legend in the top right, just outside the graph axes.
+        legend_handles = [
+            mpatches.Patch(color=bars[0].color, label=key)
+            for key, bars in figure_data.traces.items()
+        ]
+        legend = axes.legend(
+            handles=legend_handles,
+            title="Job Target",
+            alignment="left",
+            title_fontsize="large",
+            frameon=False,
+            loc="upper left",  # corner of the legend to place
+            bbox_to_anchor=(1.02, 1),  # location of the legend on the figure
+            borderaxespad=0,
+        )
+
+        axes.xaxis.grid(linewidth=0.5, alpha=0.5)
+        axes.set_axisbelow(True)
+        axes.set_xlim(0, figure_data.run_duration)
+        axes.set_xlabel("Time (s)")
+        axes.yaxis.grid(linewidth=0)
+        axes.tick_params(axis="y", length=0)
+        axes.set_ylim(0.5, figure_data.num_indices + 0.5)
+        axes.set_ylabel("Job")
+        axes.invert_yaxis()
+
+        # Enforce integer tick locations to prevent automatic interpolation of non-integer ticks.
+        axes.yaxis.set_major_locator(MaxNLocator(integer=True))
+
+        # Remove spine (border) visibility
+        for spine in ("top", "bottom", "left", "right"):
+            axes.spines[spine].set_visible(False)
+
+        # Make sure we have enough space to render the legend
+        fig.canvas.draw()
+        bbox = legend.get_window_extent()
+        legend_width_inches = bbox.width / fig.dpi
+        canvas_width, canvas_height = fig.get_size_inches()
+        fig.set_size_inches(canvas_width + legend_width_inches, canvas_height)
+
+    def _render_matplotlib_figure(self, figure_data: FigureData) -> str:
         """Render a HTML fragment with a PNG generated using matplotlib from the given data."""
         # Determine chart dimensions / scaling based on the number of jobs being rendered.
-        run_start_time, run_end_time = results.get_run_time_info()
-        run_duration = run_end_time - run_start_time
-        height = self._compute_chart_height(num_jobs)
+        height = self._compute_chart_height(figure_data.num_indices)
         width = 1.25 * DEFAULT_VISUALIZATION_HEIGHT_PX  # Default aspect ratio of 5:4
-        bar_width = self._compute_bar_thickness(num_jobs)
+        bar_width = self._compute_bar_thickness(figure_data.num_indices)
 
         # Determine figure scaling parameters.
         fig_scale_factor = 4  # Render a larger figure to preserve detail
@@ -247,59 +344,15 @@ class TimelineBarChart(InstrumentationVisualizer):
         bg_color = fig.get_facecolor()
         low_opacity_bg_color = (*bg_color[:3], 0.1)
         axes.barh(
-            y=[bar.index for bars in figure_data.values() for bar in bars],
-            width=[bar.width for bars in figure_data.values() for bar in bars],
-            left=[bar.base for bars in figure_data.values() for bar in bars],
-            color=[bar.color for bars in figure_data.values() for bar in bars],
+            y=[bar.index for bars in figure_data.traces.values() for bar in bars],
+            width=[bar.width for bars in figure_data.traces.values() for bar in bars],
+            left=[bar.base for bars in figure_data.traces.values() for bar in bars],
+            color=[bar.color for bars in figure_data.traces.values() for bar in bars],
             height=bar_width,
             linewidth=0.2,
             edgecolor=low_opacity_bg_color,
         )
-
-        title = (
-            f"Gantt chart of {num_jobs:,} scheduled jobs "
-            f"({format_time(run_duration, omit_zero=True)} run length)"
-        )
-        axes.set_title(title, fontweight="bold")
-
-        # Render the legend in the top right, just outside the graph axes.
-        legend_handles = [
-            mpatches.Patch(color=bars[0].color, label=key) for key, bars in figure_data.items()
-        ]
-        legend = axes.legend(
-            handles=legend_handles,
-            title="Job Target",
-            alignment="left",
-            title_fontsize="large",
-            frameon=False,
-            loc="upper left",  # corner of the legend to place
-            bbox_to_anchor=(1.02, 1),  # location of the legend on the figure
-            borderaxespad=0,
-        )
-
-        axes.xaxis.grid(linewidth=0.5, alpha=0.5)
-        axes.set_axisbelow(True)
-        axes.set_xlim(0, run_duration)
-        axes.set_xlabel("Time (s)")
-        axes.yaxis.grid(linewidth=0)
-        axes.tick_params(axis="y", length=0)
-        axes.set_ylim(0.5, num_jobs + 0.5)
-        axes.set_ylabel("Job")
-        axes.invert_yaxis()
-
-        # Enforce integer tick locations to prevent automatic interpolation of non-integer ticks.
-        axes.yaxis.set_major_locator(MaxNLocator(integer=True))
-
-        # Remove spine (border) visibility
-        for spine in ("top", "bottom", "left", "right"):
-            axes.spines[spine].set_visible(False)
-
-        # Make sure we have enough space to render the legend
-        fig.canvas.draw()
-        bbox = legend.get_window_extent()
-        legend_width_inches = bbox.width / fig.dpi
-        canvas_width, canvas_height = fig.get_size_inches()
-        fig.set_size_inches(canvas_width + legend_width_inches, canvas_height)
+        self._build_matplotlib_layout(fig, axes, figure_data)
 
         # Render the figure as a PNG
         buf = BytesIO()
@@ -329,15 +382,14 @@ class TimelineBarChart(InstrumentationVisualizer):
 
         """
         figure_data = self._get_figure_contents(results)
-        if not figure_data:
+        if figure_data is None or not figure_data.traces:
             return None
 
         # Dispatch to either plotly (dynamic HTML) or matplotlib (png) based on the number of
         # jobs that need to be rendered.
-        num_jobs = sum(len(jobs) for jobs in figure_data.values())
-        if self.png_threshold is None or num_jobs <= self.png_threshold:
-            return self._render_plotly_figure(results, figure_data, num_jobs)
-        return self._render_matplotlib_figure(results, figure_data, num_jobs)
+        if self.png_threshold is None or figure_data.num_jobs <= self.png_threshold:
+            return self._render_plotly_figure(figure_data)
+        return self._render_matplotlib_figure(figure_data)
 
     @classmethod
     def for_profile(cls, profile: RenderProfile) -> Self:
@@ -359,3 +411,133 @@ class TimelineBarChart(InstrumentationVisualizer):
             )
             return cls(png_threshold=None)
         return cls()
+
+
+class ParallelismChart(TimelineBarChart):
+    """A squashed timeline that shows the (simulated) parallelism in scheduling a run's jobs."""
+
+    title = "Job Parallelism"
+
+    def __init__(self, png_threshold: int | None = DEFAULT_PNG_THRESHOLD) -> None:
+        """Construct a class ParallelismChart(TimelineBarChart):.
+
+        Args:
+            png_threshold: If more than this many bars are provided, the graph will be rendered as
+              as a PNG using matplotlib for space & performance optimization. If set to `None`,
+              this will never happen, and plotly HTML will always be rendered.
+
+        """
+        super().__init__(apply_bar_scaling=True, png_threshold=png_threshold)
+
+    def _assign_indices(
+        self, jobs_by_start_time: list[tuple[str, ConcreteJobTimingMetrics]]
+    ) -> tuple[dict[str, int], int]:
+        """Squash the bar chart by assigning each job to the first unoccupied parallel index.
+
+        Args:
+            jobs_by_start_time: a list of (job_id, job timing) items pre-ordered by start time.
+
+        Returns:
+            A tuple of (mapping of job_id -> assigned index, num indices).
+
+        """
+        active: list[tuple[float, int]] = []  # heap of (end time, slot ID)
+        free_slots: list[int] = []  # heap of free slots
+        assignments: dict[str, int] = {}  # assignments of (job ID -> slot ID)
+        next_slot_id: int = 1
+
+        # Greedy assignment to get the maximum amount of parallelism (this is a lane assignment
+        # / interval coloring problem). Instead of just maintaining a heap of active slots, we
+        # update an additional heap for free slots to ensure we always make the first possible
+        # assignment for each job. This results in more comprehensible & cleaner graphs.
+        for job_id, timing in jobs_by_start_time:
+            while active and active[0][0] <= timing.start_time:
+                _, slot = heapq.heappop(active)
+                heapq.heappush(free_slots, slot)
+
+            if free_slots:
+                slot = heapq.heappop(free_slots)
+            else:
+                slot = next_slot_id
+                next_slot_id += 1
+            assignments[job_id] = slot
+            heapq.heappush(active, (timing.end_time, slot))
+
+        return assignments, next_slot_id - 1
+
+    @override
+    def _get_plotly_outline_info(self, num_indices: int) -> dict[str, Any] | None:
+        """Get the bar marker outline information to use for this Plotly figure.
+
+        When showing a parallelism chart, we always render without outlines, to avoid them
+        overlapping to form solid blocks (less visually comprehensible).
+        """
+        return {"width": 0.0}
+
+    def _extra_hover_info(
+        self, _job_id: str, _results: InstrumentationResults, index: int
+    ) -> dict[str, str]:
+        """Get a key-value mapping of extra items to put in the job's tooltip."""
+        return {"Parallel slot": str(index)}
+
+    def _build_plotly_layout(self, fig: go.Figure, figure_data: FigureData) -> None:
+        """Build the layout / presentation options for the Plotly figure."""
+        super()._build_plotly_layout(fig, figure_data)
+        fig.update_layout(
+            title_text=(
+                f"<b>Job Parallelism Visualization "
+                f"({format_time(figure_data.run_duration, omit_zero=True)} run length)</b>"
+            )
+        )
+        fig.update_yaxes(title="Parallel slot")
+
+        # For parallelism charts, use 'overlay' mode so different target traces (categories)
+        # in the same index are rendered with the same vertical offset
+        fig.update_layout(barmode="overlay")
+
+    def _build_matplotlib_layout(self, fig: MplFigure, axes: Axes, figure_data: FigureData) -> None:
+        """Build the layout / presentation options for the matplotlib figure."""
+        super()._build_matplotlib_layout(fig, axes, figure_data)
+        title = (
+            f"Job Parallelism Visualization "
+            f"({format_time(figure_data.run_duration, omit_zero=True)} run length)"
+        )
+        axes.set_title(title, fontweight="bold")
+        axes.set_ylabel("Parallel slot")
+
+    def render(self, results: InstrumentationResults) -> str | None:
+        """Render a parallelism visualization from the instrumentation results as a HTML fragment.
+
+        Also computes some additional metrics and appends them as a simple paragraph at the end
+        of the fragment. If the required job timing information is not available (or there are no
+        jobs), just returns `None` instead.
+
+        """
+        figure_data = self._get_figure_contents(results)
+        if figure_data is None or not figure_data.traces:
+            return None
+
+        # Dispatch to either plotly (dynamic HTML) or matplotlib (png) based on the number of
+        # jobs that need to be rendered.
+        if self.png_threshold is None or figure_data.num_jobs <= self.png_threshold:
+            rendered_fig = self._render_plotly_figure(figure_data)
+        else:
+            rendered_fig = self._render_matplotlib_figure(figure_data)
+
+        # Add some additional metrics (as text) describing the scheduling efficiency
+        available_compute_time = figure_data.num_indices * figure_data.run_duration
+        if available_compute_time == 0:
+            return rendered_fig
+        useful_work_time = sum(job_timing.duration for job_timing in results.job_timings().values())
+        utilization = useful_work_time / available_compute_time
+        metrics = {
+            "Degree of parallelism": str(figure_data.num_indices),
+            "Wallclock time": format_time_metric(figure_data.run_duration, omit_zero=True),
+            "Available compute time": format_time_metric(available_compute_time, omit_zero=True),
+            "Time running jobs": format_time_metric(useful_work_time, omit_zero=True),
+            "Parallel utilization": f"{utilization:.3%}",
+        }
+        rendered_fig += (
+            "<p>" + "<br>".join(f"<b>{key}</b>: {value}" for key, value in metrics.items()) + "</p>"
+        )
+        return rendered_fig


### PR DESCRIPTION
This PR is the tenth of a series of PRs to introduce instrumentation reporting to DVSim.

This PR introduces the second instrumentation report visualization, which is based on the first. A "parallelism chart" is added to show how DVSim schedules jobs in parallel over time, to help identify potential inefficiencies in DVSim itself and the structure of a run. This essentially forms a "squashed" or "collapsed" view of the previous Gantt chart visualization, simulating the parallelism that occurred within DVSim during the run.

See the commit message for more info.

---

Here are some examples of the generated `metrics.html` report from runs on the OpenTitan repository:

* A Plotly graph generated for an OpenTitan "nightly" run:
<img width="1327" height="1234" alt="image" src="https://github.com/user-attachments/assets/3af24232-2f67-4afd-96b4-378c396cf8ab" />

* A matplotlib graph generated for an OpenTitan "weekly" run:
<img width="1333" height="1262" alt="image" src="https://github.com/user-attachments/assets/fc4f92d6-f05d-455c-ba0e-1d53a155b448" />

* A Plotly graph for a local run of some OpenTitan uart smoketests:
<img width="1347" height="596" alt="image" src="https://github.com/user-attachments/assets/79fa4065-30c0-4220-832b-aa08954b3111" />