### PR TITLE
Add charts ranking the longest jobs & tests per tool to the HTML instrumentation report

### DIFF
--- a/src/dvsim/instrumentation/report/longest.py
+++ b/src/dvsim/instrumentation/report/longest.py
@@ -2,10 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-"""DVSim scheduler instrumentation bar chart visualizations of the longest jobs."""
+"""DVSim scheduler instrumentation bar chart visualizations of the longest jobs & tests."""
 
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import plotly.colors as pc
@@ -15,6 +16,7 @@ from typing_extensions import Self
 from dvsim.instrumentation import InstrumentationResults
 from dvsim.instrumentation.records import (
     ConcreteJobTimingMetrics,
+    JobInstrumentationMetadata,
     JobInstrumentationResults,
 )
 from dvsim.instrumentation.report.base import (
@@ -31,6 +33,17 @@ from dvsim.logging import log
 from dvsim.utils import format_time_metric, ordinal_suffix
 
 
+@dataclass(frozen=True)
+class TestAggregateInfo:
+    """Computed aggregate information about a test in a scheduler run."""
+
+    name: str  # name of the test
+    jobs: list[str]  # list of job IDs for different test seeds, sorted by duration, descending
+    duration: float  # combined test duration, in seconds
+    ordinal: int  # position / ranking relative to all tests, by decreasing duration
+    timings: dict[str, ConcreteJobTimingMetrics]  # mapping from test jobs to their timings
+
+
 class LongestBarChart(InstrumentationVisualizer):
     """Renders plotly bar chart figures that rank the longest jobs in the scheduler."""
 
@@ -41,16 +54,20 @@ class LongestBarChart(InstrumentationVisualizer):
     DROPDDOWN_KEY_THRESHOLD: int = 5
     ALL_KEY: str = "All categories"
 
-    # The default maximum number of bars to render for each trace (category)
+    # The default maximum number of bars and stacked bars (jobs per test) to render for each trace
     DEFAULT_MAX_BARS: int = 250
+    DEFAULT_MAX_JOBS_PER_BAR: int = 6
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         category_fn: Callable[[JobInstrumentationResults], str] | None = None,
         color_fn: Callable[[str], Any] | None = None,
+        group_tests: bool = False,
         max_bars: int | None = DEFAULT_MAX_BARS,
+        max_jobs_per_bar: int | None = None,
         allow_missing_meta: bool = False,
+        allow_isomorphic: bool = False,
     ) -> None:
         """Construct a LongestBarChart.
 
@@ -59,17 +76,48 @@ class LongestBarChart(InstrumentationVisualizer):
               will be displayed for each category, with a button to show each trace. If `None`,
               only an "overall" trace is shown.
             color_fn: Optional function to provide color mapping information for specific groups.
+            group_tests: Flag to group jobs of the same test by name. This allows timing results
+              for the same tests to be combined in a stacked bar view.
             max_bars: The maximum number of bars to show in each group (& overall).
+            max_jobs_per_bar: If group_tests=True, the maximum number of stacked bars to
+              render per bar. If there are too many bars to display, the bottom
+              (N - max_jobs_per_bar + 1) jobs will be combined into a single bar.
             allow_missing_meta: Whether the figure should still render even if metadata is missing.
+            allow_isomorphic: Whether the figure should still render even if the mapped tests are
+              isomorphic to the jobs (i.e. each job is 1-to-1 with a test; there is no extra info
+              provided by grouping the tests despite trying).
 
         """
+        if not group_tests and max_jobs_per_bar:
+            log.warning("Setting max_jobs_per_bar is meaningless without grouping jobs into tests")
+        if not group_tests and allow_isomorphic:
+            log.warning("Setting allow_isomorphic is meaningless without grouping jobs into tests")
+
         self.category_fn = category_fn
         self.color_fn = color_fn
+        self.group_tests = group_tests
         self.max_bars = max_bars
+        self.max_jobs_per_bar = max_jobs_per_bar
         self.allow_missing_meta = allow_missing_meta
+        self.allow_isomorphic = allow_isomorphic
 
         # Default margin layout information
         self.margins = {"t": 100, "b": 40, "l": 160, "r": 40}
+
+    def get_job_test(self, job_id: str, job: JobInstrumentationResults) -> str | None:
+        """Get the test name for a given job (should be the same for all seeds of a given test)."""
+        if job.meta is None:
+            return None
+
+        # Do not group non-test jobs (building, coverage merging and reporting).
+        # These can be identified by their lack of seeds at the end of their IDs.
+        if not job_id.strip().split(".")[-1].isdigit():
+            return job_id
+
+        variant_name = job.meta.block
+        if job.meta.block_variant:
+            variant_name += f"_{job.meta.block_variant}"
+        return f"{variant_name}:{job.meta.name}"
 
     def _get_job_color(
         self, color_map: dict[str, str], job: JobInstrumentationResults, key: str
@@ -79,53 +127,162 @@ class LongestBarChart(InstrumentationVisualizer):
             return color_map[self.category_fn(job)]
         return color_map[key]
 
-    def _get_top_jobs_by_category(
-        self, results: InstrumentationResults, jobs: list[str], limit: int
+    def _compute_test_aggregates(
+        self, results: InstrumentationResults
+    ) -> dict[str, TestAggregateInfo]:
+        """Combine jobs into tests (if enabled) and compute aggregate information about tests.
+
+        Args:
+            results: The instrumentation results to compute test aggregates for.
+
+        Returns:
+            A mapping of (test name -> aggregate info), ordered by decreasing duration.
+
+        """
+        job_timings = results.job_timings()
+        if not job_timings:
+            return {}
+
+        longest_jobs = sorted(job_timings.items(), key=lambda kv: kv[1].duration, reverse=True)
+
+        # Group jobs into tests if configured to do so
+        jobs_per_test: dict[str, list[str]] = defaultdict(list)
+        test_durations: dict[str, float] = defaultdict(float)
+        for job_id, timing in longest_jobs:
+            if self.group_tests:
+                test_group = self.get_job_test(job_id, results.jobs[job_id]) or job_id
+                jobs_per_test[test_group].append(job_id)
+                test_durations[test_group] += timing.duration
+            else:
+                # If no test grouping function is given, tests are isomorphic to jobs
+                jobs_per_test[job_id].append(job_id)
+                test_durations[job_id] = timing.duration
+
+        # If we get no additional data from grouping, we optionally stop rendering here.
+        if (
+            self.group_tests
+            and not self.allow_isomorphic
+            and len(jobs_per_test) == len(job_timings)
+        ):
+            log.debug("Not emitting grouped graph '%s' due to test isomorphism", self.title)
+            return {}
+
+        longest_tests = sorted(test_durations.items(), key=lambda kv: kv[1], reverse=True)
+        test_ordinals = {test_group: i for i, (test_group, _) in enumerate(longest_tests, start=1)}
+
+        # Aggregate info about each test together, returning in order of decreasing duration
+        return {
+            test: TestAggregateInfo(
+                name=test,
+                jobs=jobs_per_test[test],
+                duration=test_durations[test],
+                ordinal=ordinal,
+                timings={job: job_timings[job] for job in jobs_per_test[test]},
+            )
+            for test, ordinal in test_ordinals.items()
+        }
+
+    def _get_top_tests_by_category(
+        self, results: InstrumentationResults, tests: dict[str, TestAggregateInfo], limit: int
     ) -> dict[str, list[str]]:
-        """Split jobs into categories and get the top N jobs of each category.
+        """Split test items into categories and get the top N tests of each category.
 
         Args:
             results: The instrumentation results.
-            jobs: The list of jobs (sorted by descending duration) to filter & group.
+            tests: The mapping of tests computed from the instrumentation results.
             limit: The maximum number of jobs to be computed for each category.
 
         Returns:
-            A mapping of (category -> list of jobs), where the list of jobs are sorted in
+            A mapping of (category -> list of tests), where each list of tests is sorted in
             descending ranked order. A special case category (`self.ALL_KEY`) is also available,
-            with the top N jobs in all categories combined.
+            with the top N tests in all categories combined.
 
         """
-        # Split jobs into categories and get the top jobs of each category.
+        # Split tests into categories and get the top tests of each category.
         top_by_category: dict[str, list[str]] = defaultdict(list)
-        top_by_category[self.ALL_KEY] = jobs[:limit]
-        if self.category_fn is None:
-            return top_by_category
+        top_by_category[self.ALL_KEY] = [t.name for t in list(tests.values())[:limit]]
 
-        for job_id in jobs:
-            key = self.category_fn(results.jobs[job_id])
-            if len(top_by_category[key]) < limit:
-                top_by_category[key].append(job_id)
+        for test_group, test_info in tests.items():
+            if self.category_fn is None:
+                continue
+
+            # If we are grouping jobs into tests, check that they all report the same category.
+            # If they for some reason do not, warn and just choose the first one.
+            keys = {job_id: self.category_fn(results.jobs[job_id]) for job_id in test_info.jobs}
+            unique_keys = set(keys.values())
+            test_group_key = next(iter(unique_keys))
+            if len(unique_keys) != 1:
+                log.error(
+                    "Got multiple different categories for jobs in the same test group (%s): %s\n"
+                    "Using the first key '%s' as a fallback.",
+                    test_group,
+                    keys,
+                    test_group_key,
+                )
+            if len(top_by_category[test_group_key]) < limit:
+                top_by_category[test_group_key].append(test_group)
 
         return top_by_category
+
+    def _make_combined_bar_info(
+        self,
+        test: TestAggregateInfo,
+        jobs: list[str],
+        meta: JobInstrumentationMetadata | None,
+    ) -> tuple[float, str]:
+        """Get information for a bar that combines a subset of a test's jobs/seeds.
+
+        Args:
+            test: The test to create a combined bar for.
+            jobs: The jobs (subset of test.jobs) to create a combined bar for.
+            meta: Metadata about the test/jobs, if any exists.
+
+        Returns:
+            A tuple (combined duration, tooltip hover text) for the combined bar.
+
+        """
+        if not jobs:
+            raise ValueError("Cannot make a combined bar from a subset of no jobs.")
+
+        num_combined_jobs = len(jobs)
+        job_durations = [test.timings[job_id].duration for job_id in jobs]
+
+        total_duration = sum(job_durations)
+        max_duration = max(job_durations)
+        min_duration = min(job_durations)
+        avg_duration = total_duration / num_combined_jobs
+        rank_str = f"{test.ordinal}{ordinal_suffix(test.ordinal)} longest"
+        extra_timing_info = [
+            f"{num_combined_jobs} other jobs (combined)",
+            f"Number of seeds: {len(test.jobs)}",
+            f"Test duration (all seeds combined): {format_time_metric(test.duration)}",
+            f"Test ranking (all seeds combined): {rank_str}",
+            f"Combined duration: {format_time_metric(total_duration)}",
+            f"Maximum duration: {format_time_metric(max_duration)}",
+            f"Mean duration: {format_time_metric(avg_duration)}",
+            f"Minimum duration: {format_time_metric(min_duration)}",
+        ]
+        hover = make_job_metadata_hover(test.name, extra_timing_info, meta)
+
+        return total_duration, hover
 
     def _make_trace(
         self,
         results: InstrumentationResults,
-        jobs: list[str],
-        job_timings: dict[str, ConcreteJobTimingMetrics],
-        job_ordinals: dict[str, int],
+        test_info: list[TestAggregateInfo],
         color_map: dict[str, str],
     ) -> go.Bar:
-        """Get a plotly bar trace for a group of jobs using some defined color mapping."""
+        """Get a plotly bar trace for a group of tests using some defined color mapping."""
         # Determine max sizes for left-padding ordinals
-        max_ordinal = max(job_ordinals[job_id] for job_id in jobs)
+        max_ordinal = max(test.ordinal for test in test_info)
         ordinal_len = len(str(max_ordinal))
 
         job_names, durations, hovers, marker_colors = [], [], [], []
-        for job_id in jobs:
-            timings = job_timings[job_id]
-            ordinal = job_ordinals[job_id]
-            marker_color = self._get_job_color(color_map, results.jobs[job_id], job_id)
+        for test in test_info:
+            # Display jobs within groups shortest to longest (shortest bars first)
+            jobs = list(reversed(test.jobs))
+            first_job = results.jobs[jobs[0]]
+            marker_color = self._get_job_color(color_map, first_job, test.name)
 
             # Due to a limitation in plotly's presentation, we cannot have auto tick scaling
             # (which is needed for the size of our data) with tickmode="array", which we also
@@ -133,23 +290,51 @@ class LongestBarChart(InstrumentationVisualizer):
             # To work around this, we define shortened names that are guaranteed to be unique,
             # by prefixing them with their ordinal position (ranking).
             id_prefix = (
-                job_id
-                if len(job_id) <= self.MAX_NAME_CHARS
-                else job_id[: self.MAX_NAME_CHARS - 3] + "..."
+                test.name
+                if len(test.name) <= self.MAX_NAME_CHARS
+                else test.name[: self.MAX_NAME_CHARS - 3] + "..."
             )
-            display_name = f"{ordinal:0{ordinal_len}d}: {id_prefix} "
+            display_name = f"{test.ordinal:0{ordinal_len}d}: {id_prefix} "
 
-            extra_timing_info = {
-                "Job ranking": f"{ordinal}{ordinal_suffix(ordinal)} longest",
-                "Duration": format_time_metric(timings.duration),
-            }
-            meta = results.jobs[job_id].meta
-            hover = make_job_metadata_hover(job_id, extra_timing_info, meta)
+            # It might be too slow (and too much data) to display all the bars. If configured to
+            # do so, combine the smallest bars.
+            max_jobs = self.max_jobs_per_bar or len(jobs)
+            num_combined_jobs = len(jobs) - max_jobs + 1
+            if num_combined_jobs <= 1:
+                num_combined_jobs = 0  # If we only have 1 job to "combine", just add it normally
 
-            job_names.append(display_name)
-            durations.append(timings.duration)
-            hovers.append(hover)
-            marker_colors.append(marker_color)
+            if num_combined_jobs:
+                meta = first_job.meta
+                duration, hover = self._make_combined_bar_info(test, jobs[:num_combined_jobs], meta)
+                job_names.append(display_name)
+                durations.append(duration)
+                hovers.append(hover)
+                marker_colors.append(marker_color)
+
+            # Render the remainder of the jobs in full detail
+            for job_id in jobs[num_combined_jobs:]:
+                timings = test.timings[job_id]
+
+                extra_timing_info = {}
+                rank_str = f"{test.ordinal}{ordinal_suffix(test.ordinal)} longest"
+                if self.group_tests:
+                    extra_timing_info.update(
+                        {
+                            "Number of seeds": str(len(jobs)),
+                            "Test duration (all seeds combined)": format_time_metric(test.duration),
+                            "Test ranking (all seeds combined)": rank_str,
+                        }
+                    )
+                else:
+                    extra_timing_info["Job ranking"] = rank_str
+                extra_timing_info["Duration"] = format_time_metric(timings.duration)
+                meta = results.jobs[job_id].meta
+                hover = make_job_metadata_hover(job_id, extra_timing_info, meta)
+
+                job_names.append(display_name)
+                durations.append(timings.duration)
+                hovers.append(hover)
+                marker_colors.append(marker_color)
 
         return go.Bar(
             orientation="h",
@@ -168,29 +353,28 @@ class LongestBarChart(InstrumentationVisualizer):
         or there are no jobs, this just returns `None` instead.
 
         """
-        job_timings = results.job_timings()
-        if not job_timings:
-            return None
         if not self.allow_missing_meta and all(job.meta is None for job in results.jobs.values()):
             return None
 
-        # Order jobs by their duration (descending) and determine ordinals/rankings for each.
-        longest_jobs = sorted(job_timings.items(), key=lambda kv: kv[1].duration, reverse=True)
-        job_ordinals = {job_id: i for i, (job_id, _) in enumerate(longest_jobs, start=1)}
-        num_jobs = len(longest_jobs)
+        # Group jobs into tests if configured to do so, and compute relevant aggregate information.
+        # Tests are ordered by decreasing duration.
+        tests = self._compute_test_aggregates(results)
+        num_tests = len(tests)
+        if num_tests == 0:
+            return None
 
-        # Determine item limits & title formatting from the configured max bars.
-        if self.max_bars is None or num_jobs <= self.max_bars:
-            num_visible = num_jobs
-            title_item_desc = f"{num_jobs:,} jobs"
+        # Determine item limits & title formatting from the configured max bars & grouping.
+        item_type = "tests" if self.group_tests else "jobs"
+        if self.max_bars is None or num_tests <= self.max_bars:
+            num_visible = num_tests
+            title_item_desc = f"{num_tests:,} {item_type}"
         else:
             num_visible = self.max_bars
-            title_item_desc = f"top {num_visible} of {num_jobs} jobs"
+            title_item_desc = f"top {num_visible} of {num_tests} {item_type}"
 
-        # Bin the jobs by category (up to top `num_visible` for each). Ensure that the 'All'
+        # Bin the tests by category (up to top `num_visible` for each). Ensure that the 'All'
         # category is always ordered first.
-        ordered_jobs = [job_id for (job_id, _) in longest_jobs]
-        top_by_category = self._get_top_jobs_by_category(results, ordered_jobs, num_visible)
+        top_by_category = self._get_top_tests_by_category(results, tests, num_visible)
         categories = sorted(top_by_category, key=lambda c: (c != self.ALL_KEY, c))
         num_categories = len(categories)
 
@@ -203,8 +387,8 @@ class LongestBarChart(InstrumentationVisualizer):
         traces: list[go.Bar] = []
         menu_buttons: list[dict[str, Any]] = []
         for i, key in enumerate(categories):
-            jobs = top_by_category[key]
-            traces.append(self._make_trace(results, jobs, job_timings, job_ordinals, color_map))
+            test_info = [tests[test_group] for test_group in top_by_category[key]]
+            traces.append(self._make_trace(results, test_info, color_map))
             menu_buttons.append(
                 {
                     "label": key,
@@ -228,7 +412,7 @@ class LongestBarChart(InstrumentationVisualizer):
         fig.update_layout(
             template="plotly_white",
             showlegend=False,
-            title_text=f"<b>Jobs by longest duration ({title_item_desc})</b>",
+            title_text=f"<b>{item_type.capitalize()} by longest duration ({title_item_desc})</b>",
             title_xanchor="center",
             title_y=0.97,
             title_x=0.5,
@@ -328,3 +512,88 @@ class LongestByStatusChart(LongestBarChart):
             JobStatus.KILLED: "#12436D",
         }
         return color_mapping.get(job_status, misc_color)
+
+
+class LongestByToolChart(LongestBarChart):
+    """Renders plotly bar chart figures that rank the longest jobs or tests, partitioned by tool."""
+
+    title = "Longest Jobs by Tool"
+
+    def __init__(
+        self,
+        *,
+        group_tests: bool = False,
+        max_bars: int | None = LongestBarChart.DEFAULT_MAX_BARS,
+        max_jobs_per_bar: int | None = None,
+    ) -> None:
+        """Construct a LongestByToolChart.
+
+        Args:
+            group_tests: Flag to group jobs of the same test by name. This allows timing results
+              for the same tests to be combined in a stacked bar view.
+            max_bars: The maximum number of bars to show for each tool (and overall).
+            max_jobs_per_bar: If group_tests=True, the maximum number of stacked bars to
+              render per bar. If there are too many bars to display, the bottom
+              (N - max_jobs_per_bar + 1) jobs will be combined into a single bar.
+
+        """
+        super().__init__(
+            group_tests=group_tests,
+            category_fn=self._get_job_tool,
+            max_bars=max_bars,
+            max_jobs_per_bar=max_jobs_per_bar,
+        )
+
+    def _get_job_tool(self, job: JobInstrumentationResults) -> str:
+        """Get the tool from a job's recorded metadata, or 'Unknown' if it does not exist."""
+        return "Unknown" if job.meta is None else job.meta.tool
+
+
+class LongestTestsByToolChart(LongestByToolChart):
+    """Renders plotly bar chart figures that rank the longest tests, partitioned by tool."""
+
+    title = "Longest Tests by Tool"
+
+    DEFAULT_MAX_BARS: int = 75
+
+    def __init__(
+        self,
+        *,
+        max_bars: int | None = DEFAULT_MAX_BARS,
+        max_jobs_per_bar: int | None = LongestByToolChart.DEFAULT_MAX_JOBS_PER_BAR,
+    ) -> None:
+        """Construct a LongestTestsByToolChart.
+
+        Args:
+            max_bars: The maximum number of bars to show for each tool (and overall).
+            max_jobs_per_bar: The maximum number of stacked bars to render per bar. If there are
+              too many bars to display, the bottom (N - max_jobs_per_bar + 1) jobs will be combined
+              into a single bar.
+
+        """
+        super().__init__(group_tests=True, max_bars=max_bars, max_jobs_per_bar=max_jobs_per_bar)
+
+    @classmethod
+    def for_profile(cls, profile: RenderProfile) -> Self:
+        """Create a visualizer instance configured for a given rendering profile."""
+        if profile == RenderProfile.HIGH:
+            max_bars = cls.DEFAULT_MAX_BARS * 4
+            max_jobs_per_bar = (cls.DEFAULT_MAX_JOBS_PER_BAR - 1) * 4 + 1
+            log.debug(
+                "Using render profile '%s' for '%s' visualization. Setting max bars to %d "
+                "and max jobs per bar to %d.",
+                profile.name,
+                cls.title,
+                max_bars,
+                max_jobs_per_bar,
+            )
+            return cls(max_bars=max_bars, max_jobs_per_bar=max_jobs_per_bar)
+        if profile == RenderProfile.FULL:
+            log.debug(
+                "Using render profile '%s' for '%s' visualization. Disabling max bars and "
+                "max jobs per bar.",
+                profile.name,
+                cls.title,
+            )
+            return cls(max_bars=None, max_jobs_per_bar=None)
+        return cls()

--- a/src/dvsim/instrumentation/report/registry.py
+++ b/src/dvsim/instrumentation/report/registry.py
@@ -8,7 +8,11 @@ from typing import ClassVar
 
 from dvsim.instrumentation.report.base import InstrumentationVisualizer, RenderProfile
 from dvsim.instrumentation.report.breakdown import BlockVariantBreakdown, ToolBreakdown
-from dvsim.instrumentation.report.longest import LongestByStatusChart
+from dvsim.instrumentation.report.longest import (
+    LongestByStatusChart,
+    LongestByToolChart,
+    LongestTestsByToolChart,
+)
 from dvsim.instrumentation.report.timelines import ParallelismChart, TimelineBarChart
 from dvsim.instrumentation.report.usage import ToolUsageLineGraph
 
@@ -54,6 +58,8 @@ class ReportVisualizationRegistry:
 # Register implemented / built-in instrumentation report visualizations
 ReportVisualizationRegistry.register(LongestByStatusChart)
 ReportVisualizationRegistry.register(BlockVariantBreakdown)
+ReportVisualizationRegistry.register(LongestByToolChart)
+ReportVisualizationRegistry.register(LongestTestsByToolChart)
 ReportVisualizationRegistry.register(ToolBreakdown)
 ReportVisualizationRegistry.register(ToolUsageLineGraph)
 ReportVisualizationRegistry.register(TimelineBarChart)


### PR DESCRIPTION
This PR is the fourteenth of a series of PRs to introduce instrumentation reporting to DVSim.

This PR extends the visualization introduced in the previous PR to rank the longest jobs so that it can now rank the longest "tests" as well - where a test is a group of jobs that are running the same thing, just with different seeds. It then adds two new visualizations to the HTML instrumentation report: one ranking the top jobs partitioned by tool, and another ranking the top tests partitioned by tool.

Three key areas of note / questions:
1. For the "test" view, jobs are presented in a stacked fashion using Plotly's "overlay" mode so that we can still break the test run down into its individual jobs. This is a really cool feature... but it doesn't quite scale well to the 10k+ jobs we might want to use it for. To save performance here we only individually render the top 5 jobs per test by default, and combine the others into a single bar with aggregate info. The rendering profiles still provide a mechanism for users to retrieve more/full detail if desired, to try and keep the the default small & performant.<br></br>
2. There is some unfortunately hacky code in `LongestBarChart.get_job_test` to determine the test for a given job, so that we can group similar jobs together. It uses the presence of a seed to determine if something is a test (otherwise many "default" `build`, `cov_merge` and `cov_report` jobs are combined together), and if so uniquely identifies it by the test name and the block variant combo. In my opinion, this concept needs to be better integrated into the `JobSpec` model itself - we already have some confusion around `name` vs. `qual_name` vs. `full_name` but in this case, you can see that the granular information needed to determine test groupings is not sufficiently available (as far as I can tell), so I have to resort to this.<br></br>
3. Related to the above, in terms of naming, I *think* that "tests" is an appropriate way to refer to a "group of jobs that are basically running the same thing, with different seeds", but I'm not sure how much that concept is actually enforced in DVSim. If DVSim was made sufficiently generic in the future, this name might no longer hold? Perhaps that's a discussion for refactoring around the `FlowCfg`, `Testplan` & `Deploy` abstractions?

See the commit message for more info.

---

Here are some examples of the generated `metrics.html` report from runs on the OpenTitan repository (these can be zoomed in on when rendered in the browser):

* The "xcelium" filtered view of the top jobs by tool, generated for an OpenTitan "weekly" run:
<img width="1340" height="1179" alt="image" src="https://github.com/user-attachments/assets/a0ee0245-7733-497d-81f0-7fcee5034fca" />

* The combined "All categories" view of the top tests by tool, generated for an OpenTitan "weekly" run:
<img width="1346" height="1186" alt="image" src="https://github.com/user-attachments/assets/2e17d158-82e2-41bc-bdb6-2460c2e26244" />

* An example of the tooltip text on hover for a combined job bar in the "top tests by tool" view, generated for an OpenTitan "weekly" run:
<img width="545" height="400" alt="image" src="https://github.com/user-attachments/assets/eba4f576-1985-4ecd-88a1-b8a3f5cf1e05" />
