### PR TITLE
Add charts ranking the longest jobs & tests per block (variant) to the HTML instrumentation report

### DIFF
--- a/src/dvsim/instrumentation/report/longest.py
+++ b/src/dvsim/instrumentation/report/longest.py
@@ -597,3 +597,93 @@ class LongestTestsByToolChart(LongestByToolChart):
             )
             return cls(max_bars=None, max_jobs_per_bar=None)
         return cls()
+
+
+class LongestByBlockChart(LongestBarChart):
+    """Renders plotly bar charts that rank the longest jobs or tests, partitioned by block."""
+
+    title = "Longest Jobs by Block"
+
+    DEFAULT_MAX_BARS: int = 50
+
+    def __init__(
+        self,
+        *,
+        group_tests: bool = False,
+        max_bars: int | None = DEFAULT_MAX_BARS,
+        max_jobs_per_bar: int | None = None,
+    ) -> None:
+        """Construct a LongestByBlockChart.
+
+        Args:
+            group_tests: Flag to group jobs of the same test by name. This allows timing results
+              for the same tests to be combined in a stacked bar view.
+            max_bars: The maximum number of bars to show for each block (and overall).
+            max_jobs_per_bar: If group_tests=True, the maximum number of stacked bars to
+              render per bar. If there are too many bars to display, the bottom
+              (N - max_jobs_per_bar + 1) jobs will be combined into a single bar.
+
+        """
+        super().__init__(
+            max_bars=max_bars,
+            max_jobs_per_bar=max_jobs_per_bar,
+            category_fn=self._get_job_block_variant,
+            group_tests=group_tests,
+        )
+
+    def _get_job_block_variant(self, job: JobInstrumentationResults) -> str:
+        """Get the block (variant) from a job's metadata, or 'Unknown' if it does not exist."""
+        if job.meta is None:
+            return "Unknown"
+
+        return job.meta.block + (f"_{job.meta.block_variant}" if job.meta.block_variant else "")
+
+
+class LongestTestsByBlockChart(LongestByBlockChart):
+    """Renders plotly bar charts that rank the longest tests, partitioned by block."""
+
+    title = "Longest Tests by Block"
+
+    DEFAULT_MAX_BARS: int = 20
+
+    def __init__(
+        self,
+        *,
+        max_bars: int | None = DEFAULT_MAX_BARS,
+        max_jobs_per_bar: int | None = LongestByBlockChart.DEFAULT_MAX_JOBS_PER_BAR,
+    ) -> None:
+        """Construct a LongestTestsByBlockChart.
+
+        Args:
+            max_bars: The maximum number of bars to show for each block (and overall).
+            max_jobs_per_bar: The maximum number of stacked bars to render per bar. If there are
+              too many bars to display, the bottom (N - max_jobs_per_bar + 1) jobs will be combined
+              into a single bar.
+
+        """
+        super().__init__(group_tests=True, max_bars=max_bars, max_jobs_per_bar=max_jobs_per_bar)
+
+    @classmethod
+    def for_profile(cls, profile: RenderProfile) -> Self:
+        """Create a visualizer instance configured for a given rendering profile."""
+        if profile == RenderProfile.HIGH:
+            max_bars = cls.DEFAULT_MAX_BARS * 5
+            max_jobs_per_bar = (cls.DEFAULT_MAX_JOBS_PER_BAR - 1) * 5 + 1
+            log.debug(
+                "Using render profile '%s' for '%s' visualization. Setting max bars to %d "
+                "and max jobs per bar to %d.",
+                profile.name,
+                cls.title,
+                max_bars,
+                max_jobs_per_bar,
+            )
+            return cls(max_bars=max_bars, max_jobs_per_bar=max_jobs_per_bar)
+        if profile == RenderProfile.FULL:
+            log.debug(
+                "Using render profile '%s' for '%s' visualization. Disabling max bars and "
+                "max jobs per bar.",
+                profile.name,
+                cls.title,
+            )
+            return cls(max_bars=None, max_jobs_per_bar=None)
+        return cls()

--- a/src/dvsim/instrumentation/report/registry.py
+++ b/src/dvsim/instrumentation/report/registry.py
@@ -9,8 +9,10 @@ from typing import ClassVar
 from dvsim.instrumentation.report.base import InstrumentationVisualizer, RenderProfile
 from dvsim.instrumentation.report.breakdown import BlockVariantBreakdown, ToolBreakdown
 from dvsim.instrumentation.report.longest import (
+    LongestByBlockChart,
     LongestByStatusChart,
     LongestByToolChart,
+    LongestTestsByBlockChart,
     LongestTestsByToolChart,
 )
 from dvsim.instrumentation.report.timelines import ParallelismChart, TimelineBarChart
@@ -57,6 +59,8 @@ class ReportVisualizationRegistry:
 
 # Register implemented / built-in instrumentation report visualizations
 ReportVisualizationRegistry.register(LongestByStatusChart)
+ReportVisualizationRegistry.register(LongestByBlockChart)
+ReportVisualizationRegistry.register(LongestTestsByBlockChart)
 ReportVisualizationRegistry.register(BlockVariantBreakdown)
 ReportVisualizationRegistry.register(LongestByToolChart)
 ReportVisualizationRegistry.register(LongestTestsByToolChart)


### PR DESCRIPTION
This PR is the fifteenth of a series of PRs to introduce instrumentation reporting to DVSim.

This PR adds the final two remaining visualizations for the HTML instrumentation report implementation: one ranking the top jobs partitioned by block (variant), and another ranking the top tests partitioned by block (variant). Compared to the previous PRs, this should be a lot nicer to review - we're just extending the functionality introduced in the last two PRs via parameterization.

See the commit message for more info.

---

Here are some examples of the generated `metrics.html` report from runs on the OpenTitan repository (these can be zoomed in on when rendered in the browser):

* The "otbn" filtered view of the top jobs by block, generated for an OpenTitan "nightly" run:
<img width="1340" height="1179" alt="image" src="https://github.com/user-attachments/assets/d86166ec-c49d-4033-83c6-9d03e49e8398" />

* The combined "All categories" view of the top tests by tool, generated for an OpenTitan "weekly" run:
<img width="1340" height="1179" alt="image" src="https://github.com/user-attachments/assets/2d781ed5-6794-4969-8cec-7eb73915f1f0" />