### PR TITLE
Add a link to the instrumentation report from the sim flow HTML summary report

### DIFF
--- a/src/dvsim/sim/report.py
+++ b/src/dvsim/sim/report.py
@@ -125,13 +125,20 @@ class HtmlReportRenderer:
             if outdir is not None:
                 (outdir / block_file).write_text(artifacts[block_file])
 
+        # If instrumentation report data is available, we should also link to that generated report
+        instrumentation_report = None
+        if outdir is not None:
+            instrumentation_path = outdir / "metrics.html"
+            if instrumentation_path.exists() and instrumentation_path.is_file():
+                instrumentation_report = "metrics.html"
+
         # Regardless of whether we have a top or there is only one block, we always generate a
         # summary page for now.
         top_log_suffix = "" if summary.top is None else f" for {summary.top.name}"
         log.debug("Generating HTML summary report%s", top_log_suffix)
         artifacts["index.html"] = render_template(
             path="reports/summary_report.html",
-            data={"summary": summary},
+            data={"summary": summary, "instrumentation_report": instrumentation_report},
         )
         if outdir is not None:
             (outdir / "index.html").write_text(artifacts["index.html"])

--- a/src/dvsim/templates/reports/summary_report.html
+++ b/src/dvsim/templates/reports/summary_report.html
@@ -37,9 +37,9 @@
         </div>
     </div>
 
-    <div class="row">
+    <div class="row justify-content-between">
+        <div class="text-center mb-2">&nbsp;</div>
         <div class="col-4 col-md-3">
-            <div class="text-center mb-2">&nbsp;</div>
             <span class="badge text-bg-secondary">
                 {{ timestamp.strftime("%d/%m/%Y %H:%M:%S") }}
             </span>
@@ -54,7 +54,7 @@
                 sha: {{ meta_info.commit_short }}
             </a>
             <a class="badge text-bg-secondary link-underline link-underline-opacity-0"
-                href="index.json">json</a>
+                href="index.json">JSON</a>
             <span class="badge text-bg-secondary">
                 Branch: {{ meta_info.branch }}
             </span>
@@ -64,6 +64,14 @@
             </span>
             {% endif %}
         </div>
+        {% if instrumentation_report %}
+        <div class="col-4 col-md-3">
+            <a class="badge text-bg-secondary link-underline link-underline-opacity-0 fs-6"
+                href="{{ instrumentation_report }}">
+                Instrumentation Report
+            </a>
+        </div>
+        {% endif %}
     </div>
 
     {% macro coverage_cell(cov, kind) %}


### PR DESCRIPTION
This PR is the seventeenth of a series of PRs to introduce instrumentation reporting to DVSim.

This is intended to be merged after the visualizations have been added via the other instrumentation report PRs, but it doesn't strictly depend on them. If DVSim is run with instrumentation enabled and a report was generated, then this will place a link to that instrumentation report ("metrics.html") in the generated simulation flow report summary. The idea is to make sure that we have one central index for simulation flows from which all the generated report data can be reached.

---

Now, the generated simulation `index.html` summary report will look something like:

<img width="1326" height="229" alt="image" src="https://github.com/user-attachments/assets/d5e06d33-cc4b-4086-96c0-7ca8a7598a6b" />

With the `Instrumentation Report` button taking you to the `metrics.html` report.