### PR TITLE
refactor: Remove outdated (and unused) default repo_top argument

### DIFF
--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -330,7 +330,9 @@ class SimCfg(FlowCfg):
             self.regressions.extend(self.testplan.get_stage_regressions())
         else:
             # Create a dummy testplan with no entries.
-            self.testplan = Testplan(None, name=self.name)
+            self.testplan = Testplan(
+                "<dummy testplan>", repo_top=Path(self.proj_root), name=self.name
+            )
 
         # Create regressions
         self.regressions = Regression.create_regressions(self.regressions, self, self.tests)

--- a/src/dvsim/testplan.py
+++ b/src/dvsim/testplan.py
@@ -65,7 +65,7 @@ class Element:
     def __init__(self, raw_dict) -> None:
         """Initialize the testplan element.
 
-        raw_dict is the dictionary parsed from the HJSon file.
+        raw_dict is the dictionary parsed from the Hjson file.
         """
         # 'tags' is an optional field in addition to the mandatory self.fields.
         self.tags = []
@@ -261,7 +261,7 @@ class Testplan:
 
     @staticmethod
     def _parse_hjson(filename):
-        """Parses an input file with HJson and returns a dict."""
+        """Parses an input file with Hjson and returns a dict."""
         try:
             return hjson.load(Path(filename).open())
         except OSError:
@@ -275,7 +275,7 @@ class Testplan:
         """Create testplan elements from the list of raw dicts.
 
         kind is either 'testpoint' or 'covergroup'.
-        raw_dicts_list is a list of dictionaries extracted from the HJson file.
+        raw_dicts_list is a list of dictionaries extracted from the Hjson file.
         """
         items = []
         item_names = set()
@@ -314,13 +314,13 @@ class Testplan:
     def __init__(self, filename, repo_top=None, name=None) -> None:
         """Initialize the testplan.
 
-        filename is the HJson file that captures the testplan. It may be
+        filename is the Hjson file that captures the testplan. It may be
         suffixed with tags separated with a colon delimiter to filter the
         testpoints. For example: path/too/foo_testplan.hjson:bar:baz
         repo_top is an optional argument indicating the path to top level repo
         / project directory. It is used with filename arg.
         name is an optional argument indicating the name of the testplan / DUT.
-        It overrides the name set in the testplan HJson.
+        It overrides the name set in the testplan Hjson.
         """
         self.name = None
         self.testpoints = []
@@ -408,7 +408,7 @@ class Testplan:
         It creates the list of testpoints and covergroups extracted from the
         file.
 
-        filename is the path to the testplan file written in HJson format.
+        filename is the path to the testplan file written in Hjson format.
         repo_top is an optional argument indicating the path to repo top.
         """
         if repo_top is None:
@@ -451,7 +451,7 @@ class Testplan:
         if not testpoints and not covergroups:
             sys.exit(1)
 
-        # Any variable in the testplan that is not a recognized HJson field can
+        # Any variable in the testplan that is not a recognized Hjson field can
         # be used as a substitution variable.
         substitutions = {k: v for k, v in obj.items() if k not in self.rsvd_keywords}
         for tp in self.testpoints:
@@ -472,11 +472,11 @@ class Testplan:
             if tp.stage in tp.stages[1:]:
                 regressions[tp.stage].update({t for t in tp.tests if t})
 
-        # Build regressions dict into a hjson like data structure
+        # Build regressions dict into a Hjson-like data structure
         return [{"name": ms, "tests": list(regressions[ms])} for ms in regressions]
 
     def write_testplan_doc(self, output: TextIO) -> None:
-        """Write testplan documentation in markdown from the hjson testplan."""
+        """Write testplan documentation in markdown from the Hjson testplan."""
         stages = {}
         for tp in self.testpoints:
             stages.setdefault(tp.stage, []).append(tp)

--- a/src/dvsim/testplan.py
+++ b/src/dvsim/testplan.py
@@ -4,12 +4,11 @@
 
 """Testpoint and Testplan classes for maintaining the testplan."""
 
-import os
 import re
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 import hjson
 from tabulate import tabulate
@@ -260,15 +259,9 @@ class Testplan:
     element_cls = {"testpoint": Testpoint, "covergroup": Covergroup}
 
     @staticmethod
-    def _parse_hjson(filename):
-        """Parses an input file with Hjson and returns a dict."""
-        try:
-            return hjson.load(Path(filename).open())
-        except OSError:
-            pass
-        except hjson.scanner.HjsonDecodeError:
-            pass
-        sys.exit(1)
+    def _parse_hjson(filename: Path) -> dict[str, Any]:
+        """Parse an Hjson file at the given path and return it as a dict."""
+        return hjson.loads(Path(filename).read_text(encoding="utf-8"))
 
     @staticmethod
     def _create_testplan_elements(kind: str, raw_dicts_list: list, tags: set) -> list[Element]:
@@ -311,35 +304,36 @@ class Testplan:
         perc = value / total * 100 * 1.0
         return f"{round(perc, 2):.2f} %"
 
-    def __init__(self, filename, repo_top=None, name=None) -> None:
+    def __init__(self, tagged_filename: str, repo_top: Path, name: str) -> None:
         """Initialize the testplan.
 
-        filename is the Hjson file that captures the testplan. It may be
-        suffixed with tags separated with a colon delimiter to filter the
-        testpoints. For example: path/too/foo_testplan.hjson:bar:baz
-        repo_top is an optional argument indicating the path to top level repo
-        / project directory. It is used with filename arg.
-        name is an optional argument indicating the name of the testplan / DUT.
-        It overrides the name set in the testplan Hjson.
+        Args:
+          tagged_filename: Describes the Hjson file that captures the testplan.
+                           This is a string, rather than a Path object, because
+                           it may be suffixed with tags separated with a colon
+                           delimiter to filter the testpoints.
+
+                           For example: "path/to/foo_testplan.hjson:bar:baz"
+
+          repo_top:        The path to the top level repo / project directory.
+                           This is combined with the filename argument.
+
+          name:            The name of the testplan / DUT. It overrides any
+                           name set in the testplan Hjson.
+
         """
-        self.name = None
+        self.name = name
         self.testpoints = []
         self.covergroups = []
         self.test_results_mapped = False
 
         # Split the filename into filename and tags, if provided.
-        split = str(filename).split(":")
+        split = tagged_filename.split(":")
         filename = Path(split[0])
         tags = set(split[1:])
 
         if filename.exists():
             self._parse_testplan(filename, tags, repo_top)
-
-        if name:
-            self.name = name
-
-        if not self.name:
-            sys.exit(1)
 
         # Represents current progress towards each stage. Stage = N.A.
         # is used to indicate the unmapped tests.
@@ -402,7 +396,7 @@ class Testplan:
 
         return result
 
-    def _parse_testplan(self, filename: Path, tags: set, repo_top=None) -> None:
+    def _parse_testplan(self, filename: Path, tags: set[str], repo_top: Path) -> None:
         """Parse testplan Hjson file and create the testplan elements.
 
         It creates the list of testpoints and covergroups extracted from the
@@ -411,10 +405,6 @@ class Testplan:
         filename is the path to the testplan file written in Hjson format.
         repo_top is an optional argument indicating the path to repo top.
         """
-        if repo_top is None:
-            # Assume dvsim's original location: $REPO_TOP/util/dvsim.
-            repo_top = Path(__file__).parent.parent.parent.resolve()
-
         obj = Testplan._parse_hjson(filename)
 
         parsed = set()
@@ -430,7 +420,7 @@ class Testplan:
             if testplan in parsed:
                 sys.exit(1)
             parsed.add(testplan)
-            data = self._parse_hjson(os.path.join(repo_top, testplan))
+            data = self._parse_hjson(repo_top / testplan)
             imported_testplans.extend(
                 self._get_imported_testplan_paths(
                     testplan,
@@ -725,16 +715,16 @@ class Testplan:
         result["Pass Rate"] = self._get_percentage(tr.passing, tr.total)
         return result
 
-    def get_sim_results(self, sim_results_file, fmt="md"):
+    def get_sim_results(self, sim_results_file: str, fmt="md"):
         """Returns the mapped sim result tables in HTML formatted text.
 
-        The data extracted from the sim_results table HJson file is mapped into
+        The data extracted from the sim_results table Hjson file is mapped into
         a test results, test progress, covergroup progress and coverage tables.
 
         fmt is either 'md' (markdown) or 'html'.
         """
         assert fmt in ["md", "html"]
-        sim_results = Testplan._parse_hjson(sim_results_file)
+        sim_results = Testplan._parse_hjson(Path(sim_results_file))
         test_results_ = sim_results.get("test_results", None)
 
         test_results = []


### PR DESCRIPTION
This code was based on dvsim living inside the OpenTitan repository. Fortunately, it is never used: we always pass a third argument to _parse_testplan.

Also, fail more understandably if there is an hjson parse error or an invalid filename passed to _parse_hjson.

Finally, simplify the Testplan constructor so that it always expects a name for its testplan (rather than exiting the program silently if there isn't one).

We also change that argument to explicitly have type str (as opposed to Path) and explain why: the string can have suffix values that filter the set of tests.
