### PR TITLE
Fix status shown for combined instrumentation jobs

### DIFF
--- a/src/dvsim/instrumentation/report/longest.py
+++ b/src/dvsim/instrumentation/report/longest.py
@@ -261,7 +261,7 @@ class LongestBarChart(InstrumentationVisualizer):
             f"Mean duration: {format_time_metric(avg_duration)}",
             f"Minimum duration: {format_time_metric(min_duration)}",
         ]
-        hover = make_job_metadata_hover(test.name, extra_timing_info, meta)
+        hover = make_job_metadata_hover(test.name, extra_timing_info, meta, omit_status=True)
 
         return total_duration, hover
 


### PR DESCRIPTION
In the HTML instrumentation report, the graph showing the longest tests (where each tests is many different jobs) had an issue where, for combined job bars (rendered to reduce the number of bars being stored/shown on lower render profiles for performance reasons), the status of the first/shortest job would be reported in the metadata of the tooltip shown on hovering over the bar.

This was instead intended to not show a status at all, since there might be variation in the outcomes of these combined jobs. Fix this by adding the omitted argument.