### PR TITLE
fix: Fix name in Testplan constructor

### DIFF
--- a/src/dvsim/testplan.py
+++ b/src/dvsim/testplan.py
@@ -361,7 +361,7 @@ class Testplan:
                            name set in the testplan Hjson.
 
         """
-        self.name = None
+        self.name = name
         self.testpoints: list[Testpoint] = []
         self.covergroups: list[Covergroup] = []
         self.test_results_mapped = False


### PR DESCRIPTION
I messed this up with a mangled rebase in f328cbc. Change it back to the correct value.
