### PR TITLE
fix: Improve error message when failing to parse a testplan

### DIFF
--- a/src/dvsim/testplan.py
+++ b/src/dvsim/testplan.py
@@ -451,7 +451,7 @@ class Testplan:
             try:
                 self._parse_testplan(filename, tags, repo_top)
             except Exception as e:
-                msg = f"Error when parsing testplan at {filename}."
+                msg = f"Error when parsing testplan at {filename}: {e}"
                 raise RuntimeError(msg) from e
 
         # Represents current progress towards each stage. Stage = N.A.


### PR DESCRIPTION
This way, the error message at the bottom of the console log is rather more helpful. In the example I just ran:

RuntimeError: Error when parsing testplan at /home/rjs/work/opentitan/hw/top_earlgrey/data/chip_testplan.hjson: The otp_mutate field in the testplan element with name manuf_cp_unlock_raw is neither a string nor a list of strings.
