### PR TITLE
fix: Fix broken tp/cg filtering/update in testplan.py

### DIFF
--- a/src/dvsim/testplan.py
+++ b/src/dvsim/testplan.py
@@ -560,6 +560,19 @@ class Testplan:
         Testplan._check_duplicates("testpoint", all_tps)
         Testplan._check_duplicates("covergroup", all_cgs)
 
+        # The testplan might have been filtered with a set of tags. Apply that
+        # filter, then check that we haven't discarded everything.
+        self.testpoints = [t for t in all_tps if t.has_tags(tags)]
+        self.covergroups = [cg for cg in all_cgs if cg.has_tags(tags)]
+
+        if not (self.testpoints or self.covergroups):
+            msg = (
+                f"Merged testplan has no testpoints or covergroups, after "
+                f"filtering with tags {tags}. Before filtering, the numbers of "
+                f"testpoints and covergroups were {len(all_tps)}, {len(all_cgs)}."
+            )
+            raise ValueError(msg)
+
         # Wildcards in testpoints can mostly point to any value from the
         # object. The following names are *not* allowed (because they wouldn't
         # really make much sense).


### PR DESCRIPTION
I accidentally removed the filtering with f328cbcc. Then (worse!) removed the update to the class variable in 78c0fab.

This commit puts both back, and also now distinguishes between "there are no testpoints" and "you have filtered out all of the testpoints".
