### PR TITLE
fix: resolve the numpy nixos error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,11 @@
           };
           shellHook = ''
             unset PYTHONPATH
+            # The uv-managed .venv installs prebuilt PyPI wheels (numpy,
+            # matplotlib, ...) whose C-extensions link against system libraries
+            # that are not on NixOS's default loader path. Expose them so the
+            # wheels can be imported.
+            export LD_LIBRARY_PATH="${lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib pkgs.zlib]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
           '';
         };
       };


### PR DESCRIPTION
Fixes the numpy `libstdc++.so.6` missing error.

```
ImportError:

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy C-extensions failed. This error can happen for
many reasons, often due to issues with your setup or how NumPy was
installed.

We have compiled some common reasons and troubleshooting tips at:

    https://numpy.org/devdocs/user/troubleshooting-importerror.html

Please note and check the following:

  * The Python version is: Python 3.13 from "/home/jamesm/base/dvsim/.venv/bin/python3"
  * The NumPy version is: "2.4.6"

and make sure that they are the versions you expect.

Please carefully study the information and documentation linked above.
This is unlikely to be a NumPy issue but will be caused by a bad install
or environment on your machine.

Original error was: libstdc++.so.6: cannot open shared object file: No such file or directory
```