### PR TITLE
feat: report EDA tool version from a dedicated version query

### DIFF
--- a/src/dvsim/sim/flow.py
+++ b/src/dvsim/sim/flow.py
@@ -43,7 +43,7 @@ from dvsim.sim.report import gen_reports
 from dvsim.sim_results import BucketedFailures, SimResults
 from dvsim.test import Test
 from dvsim.testplan import Testplan
-from dvsim.tool.utils import get_sim_tool_plugin
+from dvsim.tool.utils import get_sim_tool_plugin, query_tool_version
 from dvsim.utils import TS_FORMAT, rm_path
 from dvsim.utils.fs import relative_to
 from dvsim.utils.git import git_https_url_with_commit
@@ -716,7 +716,7 @@ class SimCfg(FlowCfg):
             url=url,
             revision_info=self.revision,
         )
-        tool = ToolMeta(name=self.tool.lower(), version="unknown")
+        tool = ToolMeta(name=self.tool.lower(), version=query_tool_version(self.tool) or "unknown")
 
         build_seed = self.build_seed if not self.run_only else None
 

--- a/src/dvsim/sim/tool/base.py
+++ b/src/dvsim/sim/tool/base.py
@@ -5,8 +5,9 @@
 """EDA simulation tool interface."""
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
 
 from dvsim.job.data import JobSpec
 from dvsim.sim.data import CoverageMetrics
@@ -14,12 +15,31 @@ from dvsim.sim.data import CoverageMetrics
 if TYPE_CHECKING:
     from dvsim.job.deploy import Deploy
 
-__all__ = ("SimTool",)
+__all__ = ("SimTool", "VersionQuery")
+
+
+@dataclass(frozen=True)
+class VersionQuery:
+    """Declarative description of how to query an EDA tool for its version.
+
+    Attributes:
+        cmd: the command that makes the tool print its version.
+        pattern: a regex applied (in multiline mode) to the combined
+            stdout/stderr of ``cmd``. The first capture group is used as the
+            version string.
+
+    """
+
+    cmd: str
+    pattern: str
 
 
 @runtime_checkable
 class SimTool(Protocol):
     """Simulation tool interface required by the Sim workflow."""
+
+    version_query: ClassVar[VersionQuery | None]
+    """How to query this tool's version, or ``None`` if unsupported."""
 
     @staticmethod
     def get_cov_summary_table(cov_report_path: Path) -> tuple[Sequence[Sequence[str]], str]:

--- a/src/dvsim/sim/tool/vcs.py
+++ b/src/dvsim/sim/tool/vcs.py
@@ -7,10 +7,11 @@
 import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from dvsim.job.data import JobSpec
 from dvsim.sim.data import CodeCoverageMetrics, CoverageMetrics
+from dvsim.sim.tool.base import VersionQuery
 
 if TYPE_CHECKING:
     from dvsim.job.deploy import Deploy
@@ -20,6 +21,12 @@ __all__ = ("VCS",)
 
 class VCS:
     """Implement VCS tool support."""
+
+    # `vcs -full64 -id` reports a line like: "Compiler version = VCS X-2025.06-SP2-1_Full64".
+    version_query: ClassVar[VersionQuery | None] = VersionQuery(
+        cmd="vcs -full64 -id",
+        pattern=r"^Compiler version\s*=.*\s(\S+)$",
+    )
 
     @staticmethod
     def get_cov_summary_table(cov_report_path: Path) -> tuple[Sequence[Sequence[str]], str]:

--- a/src/dvsim/sim/tool/xcelium.py
+++ b/src/dvsim/sim/tool/xcelium.py
@@ -8,10 +8,11 @@ import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from dvsim.job.data import JobSpec
 from dvsim.sim.data import CodeCoverageMetrics, CoverageMetrics
+from dvsim.sim.tool.base import VersionQuery
 
 if TYPE_CHECKING:
     from dvsim.job.deploy import Deploy
@@ -21,6 +22,12 @@ __all__ = ("Xcelium",)
 
 class Xcelium:
     """Implement Xcelium tool support."""
+
+    # `xrun -version` reports a line like: "TOOL:   xrun(64)        24.03-s007".
+    version_query: ClassVar[VersionQuery | None] = VersionQuery(
+        cmd="xrun -version",
+        pattern=r"^TOOL:.*xrun.*\s(\S+)$",
+    )
 
     @staticmethod
     def get_cov_summary_table(cov_report_path: Path) -> tuple[Sequence[Sequence[str]], str]:

--- a/src/dvsim/tool/utils.py
+++ b/src/dvsim/tool/utils.py
@@ -4,19 +4,31 @@
 
 """EDA Tool base."""
 
+import re
+import shlex
+import subprocess
+from collections.abc import Callable
+from functools import cache
+
 from dvsim.logging import log
 from dvsim.sim.tool.base import SimTool
 from dvsim.sim.tool.vcs import VCS
 from dvsim.sim.tool.xcelium import Xcelium
 from dvsim.sim.tool.z01x import Z01X
 
-__all__ = ("get_sim_tool_plugin",)
+__all__ = ("get_sim_tool_plugin", "query_tool_version")
 
 _SUPPORTED_SIM_TOOLS = {
     "vcs": VCS,
     "xcelium": Xcelium,
     "z01x": Z01X,
 }
+
+# EDA tools should respond to a `--version`-style query near-instantly. Add a
+# timeout so a hung/misconfigured tool cannot block report generation forever.
+# However, allow a significant amount of time to allow for cold fetching from
+# a networked filesystem.
+_VERSION_QUERY_TIMEOUT_S = 120
 
 
 def get_sim_tool_plugin(tool: str) -> SimTool:
@@ -31,3 +43,93 @@ def get_sim_tool_plugin(tool: str) -> SimTool:
         raise NotImplementedError(msg)
 
     return _SUPPORTED_SIM_TOOLS[tool]
+
+
+@cache
+def _run_version_command(cmd: str) -> str | None:
+    """Run a tool version-query command, returning its combined output or None.
+
+    The tool's version may be printed to either stdout or stderr, so both are
+    captured and concatenated. Any failure to launch or run the command (the
+    tool is not on PATH, a non-EDA host, a timeout, ...) is treated as "version
+    unknown" rather than an error: querying the version must never break a run.
+
+    Results are cached for the lifetime of the process since a tool's version is
+    invariant across a single dvsim invocation; this dedupes the query when
+    multiple configs share a tool.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            shlex.split(cmd),
+            capture_output=True,
+            text=True,
+            timeout=_VERSION_QUERY_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        log.debug("Failed to query tool version via '%s': %s", cmd, e)
+        return None
+
+    return result.stdout + result.stderr
+
+
+def query_tool_version(
+    tool: str,
+    *,
+    run: Callable[[str], str | None] = _run_version_command,
+) -> str | None:
+    """Query the version of an EDA tool from the runtime environment.
+
+    Runs the tool plugin's declared version-query command and parses the version
+    out of its output. This is a local, best-effort probe: it assumes the tool
+    is available on PATH of the host running dvsim.
+
+    TODO: for farm launchers (LSF/SGE/SLURM) the tool may only exist on the
+    compute nodes. To be correct there, this should run as a lightweight
+    preflight job dispatched through the runtime backend so it inherits the same
+    environment (e.g. `module load`) as real jobs.
+
+    Args:
+        tool: the name of the tool to query (as passed to `--tool`).
+        run: callable that executes the query command and returns its combined
+            output, or None on failure. Injectable for testing.
+
+    Returns:
+        The parsed (non-empty) version string, or None if the tool declares no
+        query, the command failed, or the output did not yield a version (no
+        match, no capture group, or an empty/whitespace-only capture).
+
+    """
+    query = get_sim_tool_plugin(tool).version_query
+    if query is None:
+        return None
+
+    output = run(query.cmd)
+    if output is None:
+        return None
+
+    match = re.search(query.pattern, output, re.MULTILINE)
+    if match is None:
+        log.debug("Could not parse %s version from output of '%s'", tool, query.cmd)
+        return None
+
+    try:
+        version = match.group(1).strip()
+    except IndexError:
+        # A missing capture group is a plugin-authoring bug, but querying the
+        # version must never break a run, so log it and report "unknown".
+        log.error(
+            "version_query.pattern for tool '%s' matched but has no capture group; "
+            "it must contain one group capturing the version: %r",
+            tool,
+            query.pattern,
+        )
+        return None
+
+    if not version:
+        # An empty/whitespace capture is not a usable version; treat it as a
+        # non-match so callers never see a falsy-but-not-None version string.
+        log.debug("Parsed an empty %s version from output of '%s'", tool, query.cmd)
+        return None
+
+    return version

--- a/tests/tool/test_utils.py
+++ b/tests/tool/test_utils.py
@@ -5,12 +5,26 @@
 """Test the EDA tool utilities."""
 
 import pytest
-from hamcrest import assert_that, equal_to, instance_of
+from hamcrest import assert_that, equal_to, instance_of, none
 
-from dvsim.sim.tool.base import SimTool
-from dvsim.tool.utils import _SUPPORTED_SIM_TOOLS, get_sim_tool_plugin
+from dvsim.logging import log
+from dvsim.sim.tool.base import SimTool, VersionQuery
+from dvsim.tool.utils import _SUPPORTED_SIM_TOOLS, get_sim_tool_plugin, query_tool_version
 
-__all__ = ("TestEDAToolPlugins",)
+__all__ = ("TestEDAToolPlugins", "TestToolVersionQuery")
+
+# Representative output captured from the real tools' version-query commands.
+_VCS_ID_OUTPUT = """\
+vcs script version : X-2025.06
+machine name = dab
+machine type = linux64
+machine os = Linux 6.18.39
+The FLEXlm host ID of this machine is "1a2b3c4d5e6f 7g8h9i0j1k2l"
+Compiler version = VCS X-2025.06-SP2-1_Full64
+VCS Build Date = Jan 29 2026 20:22:37
+"""
+
+_XRUN_VERSION_OUTPUT = "TOOL:   xrun(64)        24.03-s007\n"
 
 
 class TestEDAToolPlugins:
@@ -32,3 +46,74 @@ class TestEDAToolPlugins:
         plugin = get_sim_tool_plugin(tool)
 
         assert_that(plugin, instance_of(SimTool))
+
+    @staticmethod
+    @pytest.mark.parametrize("tool", _SUPPORTED_SIM_TOOLS.keys())
+    def test_plugins_declare_version_query(tool: str) -> None:
+        """Test that every plugin declares a version query (inherited or not)."""
+        assert_that(get_sim_tool_plugin(tool).version_query, instance_of(VersionQuery))
+
+
+class TestToolVersionQuery:
+    """Test parsing of tool versions from version-query command output."""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("tool", "output", "expected"),
+        [
+            ("vcs", _VCS_ID_OUTPUT, "X-2025.06-SP2-1_Full64"),
+            ("z01x", _VCS_ID_OUTPUT, "X-2025.06-SP2-1_Full64"),
+            ("xcelium", _XRUN_VERSION_OUTPUT, "24.03-s007"),
+        ],
+    )
+    def test_parses_version(tool: str, output: str, expected: str) -> None:
+        """Test that the version is parsed from representative tool output."""
+        assert_that(query_tool_version(tool, run=lambda _cmd: output), equal_to(expected))
+
+    @staticmethod
+    def test_returns_none_when_command_fails() -> None:
+        """Test that a failed query (runner returns None) yields None."""
+        assert_that(query_tool_version("vcs", run=lambda _cmd: None), none())
+
+    @staticmethod
+    def test_returns_none_when_output_unrecognised() -> None:
+        """Test that unparseable output yields None rather than a bad version."""
+        assert_that(query_tool_version("vcs", run=lambda _cmd: "totally unexpected"), none())
+
+    @staticmethod
+    def test_returns_none_when_pattern_lacks_capture_group(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that a groupless pattern is logged and reported as unknown, not raised.
+
+        A missing capture group is a plugin-authoring bug, but querying the version must
+        never break a run, so it must be swallowed here rather than escaping as an error.
+        """
+
+        class _GrouplessPlugin:
+            # `pattern` matches the output but has no group to extract the version from.
+            version_query = VersionQuery(cmd="dummy --version", pattern="version")
+
+        monkeypatch.setattr("dvsim.tool.utils.get_sim_tool_plugin", lambda _tool: _GrouplessPlugin)
+        errors: list[tuple[object, ...]] = []
+        monkeypatch.setattr(log, "error", lambda *args, **_kwargs: errors.append(args))
+
+        result = query_tool_version("vcs", run=lambda _cmd: "version 1.2.3")
+
+        assert_that(result, none())
+        assert_that(len(errors), equal_to(1))
+        assert_that(errors[0][1], equal_to("vcs"))
+
+    @staticmethod
+    def test_returns_none_when_match_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that a capture of an empty/whitespace version yields None, not ''.
+
+        This upholds the contract that a truthy version string is returned or None,
+        so callers never have to treat "" as a distinct, meaningless version.
+        """
+
+        class _EmptyMatchPlugin:
+            # The group matches, but captures no non-whitespace version token.
+            version_query = VersionQuery(cmd="dummy --version", pattern=r"version:\s*(\S*)")
+
+        monkeypatch.setattr("dvsim.tool.utils.get_sim_tool_plugin", lambda _tool: _EmptyMatchPlugin)
+
+        assert_that(query_tool_version("vcs", run=lambda _cmd: "version: \n"), none())


### PR DESCRIPTION
<!--
CONTRIBUTION GUIDELINES
=======================

For a full reference, refer to the following documents:
- CONTRIBUTING.md
- CLA

COMMIT FORMAT
=============
Each commit merged from this PR drives an automatic release. Choose the right
type — it directly determines the version bump on the next release.

  TYPE        SEMVER IMPACT    USE WHEN...
  ─────────────────────────────────────────────────────────────────────────────
  feat        minor bump       adding new user-facing behaviour or CLI options
  fix         patch bump       correcting a bug in existing behaviour
  perf        patch bump       improving performance without changing behaviour
  refactor    patch bump       restructuring code without changing behaviour
  docs        no release       documentation-only changes
  test        no release       adding or fixing tests
  ci          no release       CI workflow changes
  chore       no release       maintenance (deps, tooling, config)
  build       no release       build system changes
  revert      patch bump       reverting a previous commit

BREAKING CHANGES → major bump
  Append ! to the type:  feat!: remove --legacy-flag
  Or add a footer:       BREAKING CHANGE: <description>

FORMAT
  <type>[(<scope>)][!]: <short description>   ← 100 chars max
  <blank line>
  <optional body>
  <blank line>
  Signed-off-by: Name <email>                 ← required; use git commit -s

EXAMPLES
  feat(scheduler): add --max-jobs CLI flag
  fix: handle empty testplan gracefully
  feat!: remove Python 3.9 support
  refactor(sim): extract tool selection into factory

For further info about the release processes, refer to the the following documents:
- doc/releasing.md
-->

## Description

Replace the hardcoded "unknown" tool version in reports with a value probed from the tool at runtime. Each SimTool plugin declares a VersionQuery (command + regex) as data, and a single generic runner executes it, so adding a tool needs no new logic. Any failure falls back to "unknown".

A tool version is now printed inside the final report badge. E.g.
<img width="553" height="234" alt="image" src="https://github.com/user-attachments/assets/0ed20735-77f9-42db-a97d-a0d27819d54f" />


## Checklist

- [x] All commits are signed off (`git commit -s`), indicating acceptance of the CLA
- [x] Commit messages follow the conventional commit format (`<type>[(<scope>)][!]: <description>`)
  - [x] The commit type correctly reflects the semver impact of the change
  - [x] Breaking changes are marked with `!` or a `BREAKING CHANGE:` footer
- [x] New behaviour is covered by tests
