### PR TITLE
feat: dependabot init

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Dependabot configuration.
+#
+# This file configures Dependabot *version updates* (the weekly proactive
+# refresh of dependencies). It is also consulted when Dependabot opens
+# *security updates* -- the PRs raised automatically whenever a vulnerability
+# advisory is reported by the Dependabot alert scan. Security updates are
+# enabled via the repository's Code security settings (not this file), but they
+# inherit the PR-shaping options below (commit-message prefix, labels, ...) from
+# the `updates` entry whose `package-ecosystem` + `directory` match the
+# vulnerable manifest. Security updates are event-driven and ignore `schedule`.
+version: 2
+updates:
+  # Python dependencies -- uv.lock / pyproject.toml.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      # Repo requires conventional-commit prefixes (feat/fix/refactor/perf);
+      # "fix" keeps both version and security PRs passing lint_commits.py.
+      prefix: "fix"
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+
+  # GitHub Actions used in the CI and release workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "fix"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/scripts/lint_commits.py
+++ b/scripts/lint_commits.py
@@ -35,6 +35,15 @@ CONVENTIONAL_COMMIT_TYPES = {
 # Matches: <type>[(<scope>)][!]: <description>
 CONVENTIONAL_COMMIT_RE = re.compile(r"^(?P<type>[a-z]+)(\([^)]+\))?!?: .+")
 
+# Author names whose commits are exempt from these checks. Dependabot opens
+# dependency-update PRs automatically; its commits use a GitHub noreply email
+# and carry no Signed-off-by line, so they can satisfy neither the author email
+# check nor the CLA signoff check. The CLA does not apply to these automated
+# bumps, so we skip linting them entirely rather than fail every Dependabot PR.
+EXEMPT_AUTHOR_NAMES = {
+    "dependabot[bot]",
+}
+
 
 def error(msg: str, commit: str | None = None) -> None:
     """Log error."""
@@ -182,6 +191,10 @@ def lint_commit_message(commit: str) -> bool:
 
 def lint_commit(commit: str) -> bool:
     """Check a commit."""
+    if commit.author.name in EXEMPT_AUTHOR_NAMES:
+        logger.info("Skipping lint for exempt bot author %r.", commit.author.name)
+        return True
+
     return all(
         [
             lint_commit_author(commit),


### PR DESCRIPTION
<!--
CONTRIBUTION GUIDELINES
=======================

For a full reference, refer to the following documents:
- CONTRIBUTING.md
- CLA

COMMIT FORMAT
=============
Each commit merged from this PR drives an automatic release. Choose the right
type — it directly determines the version bump on the next release.

  TYPE        SEMVER IMPACT    USE WHEN...
  ─────────────────────────────────────────────────────────────────────────────
  feat        minor bump       adding new user-facing behaviour or CLI options
  fix         patch bump       correcting a bug in existing behaviour
  perf        patch bump       improving performance without changing behaviour
  refactor    patch bump       restructuring code without changing behaviour
  docs        no release       documentation-only changes
  test        no release       adding or fixing tests
  ci          no release       CI workflow changes
  chore       no release       maintenance (deps, tooling, config)
  build       no release       build system changes
  revert      patch bump       reverting a previous commit

BREAKING CHANGES → major bump
  Append ! to the type:  feat!: remove --legacy-flag
  Or add a footer:       BREAKING CHANGE: <description>

FORMAT
  <type>[(<scope>)][!]: <short description>   ← 100 chars max
  <blank line>
  <optional body>
  <blank line>
  Signed-off-by: Name <email>                 ← required; use git commit -s

EXAMPLES
  feat(scheduler): add --max-jobs CLI flag
  fix: handle empty testplan gracefully
  feat!: remove Python 3.9 support
  refactor(sim): extract tool selection into factory

For further info about the release processes, refer to the the following documents:
- doc/releasing.md
-->

## Description

Add `.github/dependabot.yml` to keep dependencies current and to react to
reported vulnerabilities.

Coverage:
- Weekly version updates for the Python dependencies (uv ecosystem, driven
  by `uv.lock` / `pyproject.toml`) and for the GitHub Actions used in the CI and
  release workflows. Updates are grouped into a single PR per ecosystem.
- Dependabot security updates (enabled via the repository Code security
  settings, not this file) are event-driven: they raise a PR as soon as the
  alert scan reports a new advisory, independent of the weekly schedule. They
  inherit the PR-shaping options here (commit-message prefix, labels) via the
  matching package-ecosystem + directory entry.

The "fix" commit-message prefix keeps both version and security PRs compatible
with the conventional-commit check in `scripts/lint_commits.py`, which would
otherwise reject Dependabot's default "build(deps):" prefix.

## Checklist

- [x] All commits are signed off (`git commit -s`), indicating acceptance of the CLA
- [x] Commit messages follow the conventional commit format (`<type>[(<scope>)][!]: <description>`)
  - [x] The commit type correctly reflects the semver impact of the change
  - [x] Breaking changes are marked with `!` or a `BREAKING CHANGE:` footer
- [ ] New behaviour is covered by tests
