### PR TITLE
fix: use increase versioning-strategy for uv dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Bump the lower bound (e.g. ">=3.1.58" -> ">=3.1.59") rather than letting the
+    # default (widen-flavoured) strategy run. The uv updater's default path collapses
+    # a bounded requirement into the invalid PEP 508 string "name*", which fails CI at
+    # `uv sync` (see dependabot/dependabot-core#15639). "increase" avoids that path.
+    versioning-strategy: increase
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Problem

Every Dependabot PR that bumps a **direct** Python dependency currently ships a broken `pyproject.toml`. The `uv` updater's default (widen-flavoured) strategy collapses a bounded requirement into an invalid PEP 508 string — e.g. in #262 it rewrote:

```diff
-    "gitpython>=3.1.58",
+    "gitpython*",
```

`"gitpython*"` is not valid PEP 508 (a bare `*` with no operator), so CI fails at the install step for **every** job:

```
error: Failed to generate package metadata for `dvsim ... editable+.`
  ValueError: Dependency #4 of field `project.dependencies` is invalid:
    Expected semicolon (after name with no version specifier) or end
      gitpython*
```

The generated `uv.lock` half is correct; only the manifest rewrite is broken. Transitive-only bumps are unaffected (they never touch `pyproject.toml`), which is why the failures look intermittent. To date these PRs have been merged only after hand-fixing each specifier.

This is upstream bug [dependabot/dependabot-core#15639](https://github.com/dependabot/dependabot-core/issues/15639) (open).

## Fix

Set `versioning-strategy: increase` on the `uv` update entry. `versioning-strategy` [is supported for the uv ecosystem](https://github.com/dependabot/dependabot-core/issues/12162) (uv's updater inherits Python's `RequirementsUpdater`). `increase` bumps the **lower bound** instead of widening — `">=3.1.58"` → `">=3.1.59"` — which is valid PEP 508, matches the manifest's existing floor style, and keeps floors from silently going stale.

This PR includes AI-assisted content generated with Claude Code. All changes have been reviewed and are the responsibility of the listed author(s).